### PR TITLE
We have a bug with this model definition, forcing nullable

### DIFF
--- a/openid_provider/models.py
+++ b/openid_provider/models.py
@@ -108,7 +108,7 @@ class UserInfo(models.Model):
     address_region = models.CharField(max_length=255, default='')
     address_postal_code = models.CharField(max_length=255, default='')
     address_country = models.CharField(max_length=255, default='')
-    updated_at = models.DateTimeField(auto_now=True)
+    updated_at = models.DateTimeField(auto_now=True, null=True)
 
     @property
     def name(self):


### PR DESCRIPTION
Sending change to avoid this issue during inserts

IntegrityError('null value in column "updated_at" violates not-null constraint