### PR TITLE
Add __str__ and __unicode__ to models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.py[cod]
 *.egg-info
 .ropeproject
+src/

--- a/DOC.md
+++ b/DOC.md
@@ -46,6 +46,8 @@ Install the package using pip.
 pip install django-oidc-provider
 # Or latest code from repo.
 pip install git+https://github.com/juanifioren/django-oidc-provider.git#egg=oidc_provider
+# Or if working from a local repo
+pip install git+./#egg=oidc_provider
 ```
 
 Add it to your apps.

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -21,6 +21,12 @@ class Client(models.Model):
 
     _redirect_uris = models.TextField(default='')
 
+    def __str__(self):
+        return self.name
+
+    def __unicode__(self):
+        return self.__str__()
+    
     def redirect_uris():
         def fget(self):
             return self._redirect_uris.splitlines()
@@ -40,6 +46,7 @@ class BaseCodeTokenModel(models.Model):
     client = models.ForeignKey(Client)
     expires_at = models.DateTimeField()
     _scope = models.TextField(default='')
+
     def scope():
         def fget(self):
             return self._scope.split()
@@ -51,6 +58,12 @@ class BaseCodeTokenModel(models.Model):
     def has_expired(self):
         return timezone.now() >= self.expires_at
 
+    def __str__(self):
+        return "%s - %s (%s)" % (self.client, self.user, self.expires_at)
+
+    def __unicode__(self):
+        return self.__str__()
+    
     class Meta:
         abstract = True
 


### PR DESCRIPTION
Before the change, using the django admin, the list of Clients looked like a list of `<Client object>`. This made it was impossible to browse to the one you want. The change causes the client's name to be shown instead, which makes it much easier.

Also added 2 lines of instructions to DOC.md, for installing from a local repository. And tweaked .gitignore because pip makes a `src/` folder when installing from a local repository that you probably don't want committed to the repository. That was just annoying me when adding the __str__ and __unicode__ methods.