### PR TITLE
Add nonce in id_token when included in auth request

### DIFF
--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -33,6 +33,7 @@ class TokenEndpoint(object):
         self.params.grant_type = query_dict.get('grant_type', '')
         self.params.code = query_dict.get('code', '')
         self.params.state = query_dict.get('state', '')
+        self.params.nonce = query_dict.get('nonce', '')
 
     def validate_params(self):
         if not (self.params.grant_type == 'authorization_code'):
@@ -70,7 +71,9 @@ class TokenEndpoint(object):
     def create_response_dic(self):
         id_token_dic = create_id_token(
             user=self.code.user,
-            aud=self.client.client_id)
+            aud=self.client.client_id,
+            nonce=self.params.nonce,
+        )
 
         token = create_token(
             user=self.code.user,

--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -10,7 +10,7 @@ from oidc_provider.models import *
 from oidc_provider import settings
 
 
-def create_id_token(user, aud):
+def create_id_token(user, aud, nonce=None):
     """
     Receives a user object and aud (audience).
     Then creates the id_token dictionary.
@@ -39,6 +39,9 @@ def create_id_token(user, aud):
         'iat': iat_time,
         'auth_time': auth_time,
     }
+
+    if nonce:
+        dic['nonce'] = nonce
 
     return dic
 


### PR DESCRIPTION
http://openid.net/specs/openid-connect-core-1_0.html#IDToken

If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request.

This patch adds the nonce to the id_token.