### PR TITLE
Fix types

### DIFF
--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -25,11 +25,11 @@ def create_id_token(user, aud, nonce=None):
 
     now = timezone.now()
     # Convert datetimes into timestamps.
-    iat_time = time.mktime(now.timetuple())
-    exp_time = time.mktime((now + timedelta(seconds=expires_in)).timetuple())
+    iat_time = int(time.mktime(now.timetuple()))
+    exp_time = int(time.mktime((now + timedelta(seconds=expires_in)).timetuple()))
 
     user_auth_time = user.last_login or user.date_joined
-    auth_time = time.mktime(user_auth_time.timetuple())
+    auth_time = int(time.mktime(user_auth_time.timetuple()))
 
     dic = {
         'iss': get_issuer(),

--- a/oidc_provider/settings.py
+++ b/oidc_provider/settings.py
@@ -56,7 +56,7 @@ class DefaultSettings(object):
         OPTIONAL.
         """
         def default_sub_generator(user):
-            return user.id
+            return str(user.id)
 
         return default_sub_generator
 


### PR DESCRIPTION
* Make iat_time, exp_time, auth_time an integer, not a float. The spec
does not explicitly forbit float times, but some clients don't accept
this (mod_auth_openidc), and `timetuple()` has second precision anyway
so we don't loose any information.
* Make the `sub` a string in the default sub generator. The spec says "The sub value is a case
sensitive string."