### PR TITLE
Fix for custom user class

### DIFF
--- a/oidc_provider/lib/endpoints/authorize.py
+++ b/oidc_provider/lib/endpoints/authorize.py
@@ -12,6 +12,7 @@ from oidc_provider.lib.errors import *
 from oidc_provider.lib.utils.params import *
 from oidc_provider.lib.utils.token import *
 from oidc_provider.models import *
+from oidc_provider import settings
 
 
 logger = logging.getLogger(__name__)

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -2,7 +2,7 @@ import json
 
 from django.db import models
 from django.utils import timezone
-from django.contrib.auth.models import User
+from django.conf import settings
 
 
 class Client(models.Model):
@@ -42,7 +42,7 @@ class Client(models.Model):
 
 class BaseCodeTokenModel(models.Model):
 
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL)
     client = models.ForeignKey(Client)
     expires_at = models.DateTimeField()
     _scope = models.TextField(default='')
@@ -94,7 +94,7 @@ class UserInfo(models.Model):
         ('M', 'Male'),
     ]
 
-    user = models.OneToOneField(User, primary_key=True)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, primary_key=True)
     given_name = models.CharField(max_length=255, blank=True, null=True)
     family_name = models.CharField(max_length=255, blank=True, null=True)
     middle_name = models.CharField(max_length=255, blank=True, null=True)


### PR DESCRIPTION
In Django you can define a custom User class. This should be [properly referenced](https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#referencing-the-user-model) to correctly function.

Other things that should be modified to properly use a custom model are:
 * OIDC_IDTOKEN_SUB_GENERATOR should point to a function that correctly extracts the id from the custom model
 * The standard scope claims reference some fields of the User model, so it should be possible to provide a custom ScopeClaims class (instead of just adding extra scope claims). I'll make a separate PR to enable this.