### PR TITLE
Don't filter all falsey claims

### DIFF
--- a/oidc_provider/lib/claims.py
+++ b/oidc_provider/lib/claims.py
@@ -53,7 +53,7 @@ class AbstractScopeClaims(object):
         aux_dic = dic.copy()
         for key, value in iter(dic.items()):
 
-            if not value:
+            if value is None or value == '':
                 del aux_dic[key]
             elif type(value) is dict:
                 aux_dic[key] = self._clean_dic(value)


### PR DESCRIPTION
Sometimes you do want the value False, or 0, or a datetime value at midnight. (see http://lwn.net/Articles/590299/)

Maybe there are cases where you want to filter out empty sequences/dicts?