### PR TITLE
Implement refresh_token flow

### DIFF
--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -163,9 +163,8 @@ class TokenEndpoint(object):
         # Store the token.
         token.save()
 
-        # We don't need to store the code anymore.
-        self.token.refresh_token = None
-        self.token.save()
+        # Forget the old token.
+        self.token.delete()
 
         dic = {
             'access_token': token.access_token,

--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -35,6 +35,8 @@ class TokenEndpoint(object):
         self.params.grant_type = self.request.POST.get('grant_type', '')
         self.params.code = self.request.POST.get('code', '')
         self.params.state = self.request.POST.get('state', '')
+        self.params.scope = self.request.POST.get('scope', '')
+        self.params.refresh_token = self.request.POST.get('refresh_token', '')
 
     def _extract_client_auth(self):
         """
@@ -60,23 +62,29 @@ class TokenEndpoint(object):
         return (client_id, client_secret)
 
     def validate_params(self):
-        if not (self.params.grant_type == 'authorization_code'):
-            logger.error('[Token] Invalid grant type: %s', self.params.grant_type)
-            raise TokenError('unsupported_grant_type')
-
         try:
             self.client = Client.objects.get(client_id=self.params.client_id)
 
-            if not (self.client.client_secret == self.params.client_secret):
-                logger.error('[Token] Invalid client secret: client %s do not have secret %s',
-                             self.client.client_id, self.client.client_secret)
-                raise TokenError('invalid_client')
+        except Client.DoesNotExist:
+            logger.error('[Token] Client does not exist: %s', self.params.client_id)
+            raise TokenError('invalid_client')
 
+        if not (self.client.client_secret == self.params.client_secret):
+            logger.error('[Token] Invalid client secret: client %s do not have secret %s',
+                         self.client.client_id, self.client.client_secret)
+            raise TokenError('invalid_client')
+
+        if self.params.grant_type == 'authorization_code':
             if not (self.params.redirect_uri in self.client.redirect_uris):
                 logger.error('[Token] Invalid redirect uri: %s', self.params.redirect_uri)
                 raise TokenError('invalid_client')
 
-            self.code = Code.objects.get(code=self.params.code)
+            try:
+                self.code = Code.objects.get(code=self.params.code)
+
+            except Code.DoesNotExist:
+                logger.error('[Token] Code does not exist: %s', self.params.code)
+                raise TokenError('invalid_grant')
 
             if not (self.code.client == self.client) \
                or self.code.has_expired():
@@ -84,15 +92,33 @@ class TokenEndpoint(object):
                              self.params.redirect_uri)
                 raise TokenError('invalid_grant')
 
-        except Client.DoesNotExist:
-            logger.error('[Token] Client does not exist: %s', self.params.client_id)
-            raise TokenError('invalid_client')
+        elif self.params.grant_type == 'refresh_token':
+            if not self.params.refresh_token:
+                logger.error('[Token] Missing refresh token')
+                raise TokenError('invalid_grant')
 
-        except Code.DoesNotExist:
-            logger.error('[Token] Code does not exist: %s', self.params.code)
-            raise TokenError('invalid_grant')
+            try:
+                self.token = Token.objects.get(refresh_token=self.params.refresh_token,
+                                               client=self.client)
+
+            except Token.DoesNotExist:
+                logger.error('[Token] Refresh token does not exist: %s', self.params.refresh_token)
+                raise TokenError('invalid_grant')
+
+        else:
+            logger.error('[Token] Invalid grant type: %s', self.params.grant_type)
+            raise TokenError('unsupported_grant_type')
 
     def create_response_dic(self):
+        if self.params.grant_type == 'authorization_code':
+            return self.create_code_response_dic()
+        elif self.params.grant_type == 'refresh_token':
+            return self.create_refresh_response_dic()
+        else:
+            # Should have already been catched by validate_params
+            raise RuntimeError('Invalid grant type')
+
+    def create_code_response_dic(self):
         id_token_dic = create_id_token(
             user=self.code.user,
             aud=self.client.client_id,
@@ -113,6 +139,37 @@ class TokenEndpoint(object):
 
         dic = {
             'access_token': token.access_token,
+            'refresh_token': token.refresh_token,
+            'token_type': 'bearer',
+            'expires_in': settings.get('OIDC_TOKEN_EXPIRE'),
+            'id_token': encode_id_token(id_token_dic),
+        }
+
+        return dic
+
+    def create_refresh_response_dic(self):
+        id_token_dic = create_id_token(
+            user=self.token.user,
+            aud=self.client.client_id,
+            nonce=None,
+        )
+
+        token = create_token(
+            user=self.token.user,
+            client=self.token.client,
+            id_token_dic=id_token_dic,
+            scope=self.token.scope)
+
+        # Store the token.
+        token.save()
+
+        # We don't need to store the code anymore.
+        self.token.refresh_token = None
+        self.token.save()
+
+        dic = {
+            'access_token': token.access_token,
+            'refresh_token': token.refresh_token,
             'token_type': 'bearer',
             'expires_in': settings.get('OIDC_TOKEN_EXPIRE'),
             'id_token': encode_id_token(id_token_dic),

--- a/oidc_provider/migrations/0005_token_refresh_token.py
+++ b/oidc_provider/migrations/0005_token_refresh_token.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oidc_provider', '0004_remove_userinfo'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='token',
+            name='refresh_token',
+            field=models.CharField(max_length=255, unique=True, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -77,6 +77,7 @@ class Code(BaseCodeTokenModel):
 class Token(BaseCodeTokenModel):
 
     access_token = models.CharField(max_length=255, unique=True)
+    refresh_token = models.CharField(max_length=255, unique=True, null=True)
     _id_token = models.TextField()
     def id_token():
         def fget(self):

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     ],
     tests_require=[
         'pyjwkest==1.0.1',
+        'mock==1.3.0',
     ],
 
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     django17: django==1.7
     django18: django==1.8
     coverage
+    mock
 
 commands =
     pip install -e .


### PR DESCRIPTION
This PR adds the possibility to refresh expired JWT/acces_tokens by using a refresh token as described in http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.12.

The refresh token is stored with the Token and usage of a refresh token will issue a new Token and invalidate the old one.