### PR TITLE
Upgrade pyjwkest to version >= 1.0.3

### DIFF
--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -56,9 +56,7 @@ def encode_id_token(payload):
     key_string = get_rsa_key().encode('utf-8')
     keys = [ RSAKey(key=importKey(key_string), kid=md5(key_string).hexdigest()) ]
     _jws = JWS(payload, alg='RS256')
-    _jwt = _jws.sign_compact(keys)
-
-    return _jwt.decode('utf-8')
+    return _jws.sign_compact(keys)
 
 
 def create_token(user, client, id_token_dic, scope):

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,10 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     tests_require=[
-        'pyjwkest==1.0.1',
+        'pyjwkest>=1.0.3,<1.1',
     ],
 
     install_requires=[
-        'pyjwkest==1.0.1',
+        'pyjwkest>=1.0.3,<1.1',
     ],
 )


### PR DESCRIPTION
There have been some issues in Python 3 where elements of the id_token
were left when encoding the token. Cause was incorrect encoding logic in
pyjwkest. Version 1.0.3 has improved encoding handling.

I restricted the version to less than 1.1, assuming that the interface of pyjwkest won't change when only the patch level is changed. (Although as you can see `sign_compact` started to return a str instead of bytes in 1.0.3, so fingers crossed...)