### PR TITLE
Fix creatersakey management command support for Python 3.x

### DIFF
--- a/oidc_provider/management/commands/creatersakey.py
+++ b/oidc_provider/management/commands/creatersakey.py
@@ -1,7 +1,7 @@
 from Crypto.PublicKey import RSA
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):

--- a/oidc_provider/management/commands/creatersakey.py
+++ b/oidc_provider/management/commands/creatersakey.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
         try:
             key = RSA.generate(1024)
             file_path = settings.BASE_DIR + '/OIDC_RSA_KEY.pem'
-            with open(file_path, 'w') as f:
+            with open(file_path, 'wb') as f:
                 f.write(key.exportKey('PEM'))
             self.stdout.write('RSA key successfully created at: ' + file_path)
         except Exception as e:

--- a/oidc_provider/management/commands/creatersakey.py
+++ b/oidc_provider/management/commands/creatersakey.py
@@ -15,4 +15,4 @@ class Command(BaseCommand):
                 f.write(key.exportKey('PEM'))
             self.stdout.write('RSA key successfully created at: ' + file_path)
         except Exception as e:
-            self.stdout.write('Something goes wrong: ' + e.message)
+            self.stdout.write('Something goes wrong: {0}'.format(e))

--- a/oidc_provider/tests/test_creatersakey_command.py
+++ b/oidc_provider/tests/test_creatersakey_command.py
@@ -1,0 +1,11 @@
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+from django.utils.six import StringIO
+
+
+class CreateRSAKeyTest(TestCase):
+    @override_settings(BASE_DIR='/tmp')
+    def test_command_output(self):
+        out = StringIO()
+        call_command('creatersakey', stdout=out)
+        self.assertIn('RSA key successfully created', out.getvalue())


### PR DESCRIPTION
This pull request proposes a fix for https://github.com/juanifioren/django-oidc-provider/issues/51.

I've added a basic test for the command and after that I've made the changes to keep the test suite healthy.

Please tell if it's ok for you, thanks.