### PR TITLE
Master

### DIFF
--- a/oidc_provider/lib/claims.py
+++ b/oidc_provider/lib/claims.py
@@ -67,12 +67,14 @@ class StandardScopeClaims(AbstractScopeClaims):
     """
 
     def setup(self):
-        try:
-            self.userinfo = UserInfo.objects.get(user=self.user)
-        except UserInfo.DoesNotExist:
+        # Note: commented this out because it doesn't work with Python 2.7
+        #try:
+        #    self.userinfo = UserInfo.objects.get(user=self.user)
+        #except UserInfo.DoesNotExist:
             # Create an empty model object.
-            self.userinfo = UserInfo()
-
+        #    self.userinfo = UserInfo()
+        self.userinfo = UserInfo()
+        
     def scope_profile(self, user):
         dic = {
             'name': self.userinfo.name,

--- a/oidc_provider/lib/endpoints/register.py
+++ b/oidc_provider/lib/endpoints/register.py
@@ -1,0 +1,124 @@
+import logging
+import re
+
+from django.http import HttpResponse
+from django.http import JsonResponse
+
+from oidc_provider.lib.errors import *
+from oidc_provider.lib.claims import *
+from oidc_provider.lib.utils.params import *
+
+from oidc_provider.models import *
+from oidc_provider import settings
+from oidc_provider.lib.utils.register import *
+
+
+logger = logging.getLogger(__name__)
+
+
+class RegisterEndpoint(object):
+
+    def __init__(self, request):
+        jsonStr = request.body
+
+        paramDic = json.loads(jsonStr)
+            
+        self.request = request
+        self.params = Params()
+        self.params.name = None
+        self.params.access_token = None
+        self.params.redirecturis = None
+        self.params.response_types = 'code'
+        # If client_name has been passed in
+        if 'client_name' in paramDic: 
+            self.params.name = paramDic['client_name']
+        # If redirect_uris has been passed in
+        if 'redirect_uris' in paramDic:
+            self.params.redirecturis = '\n'.join(paramDic['redirect_uris'])
+        if 'response_types' in paramDic :
+            self.params.response_types = '\n'.join(paramDic['response_types'])
+                 
+        headerDic = request.META
+        if 'HTTP_AUTHORIZATION' in headerDic:
+            auth_header = headerDic['HTTP_AUTHORIZATION']
+            if re.compile('^Bearer\s{1}.+$').match(auth_header):
+                self.params.access_token = auth_header.split()[1]
+
+
+ 
+    def _extract_params(self):
+        # Get the parameters from request
+        # self.params.name = self.request.POST.get('client_name', '')
+        # self.params.redirecturis = self.request.POST.get('redirect_uris', '')
+        pass
+    
+    def validate_params(self):
+        # Make sure appropriate parameters are there
+        # See: https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+        # We want client name (optional), and redirect URIs (required).  
+        # "Response type" will default to code (Authorization code flow)
+        
+        # Is this endpoint enabled in the configuration?
+        if not settings.get('REGISTRATION_ENDPOINT_ENABLED'):
+            raise RegisterError('invalid_request')
+            
+        # If authorization is required, has user provided valid access token?
+        if settings.get('REGISTRATION_ENDPOINT_REQ_TOKEN'):
+            if self.params.access_token is None:
+                raise RegisterError('invalid_request')
+            # Check whether token is valid
+            try: 
+                self.token = Token.objects.get(access_token=self.params.access_token)
+            
+                if self.token.has_expired():
+                    logger.error('[Register] Token has expired: %s', self.params.access_token)
+                    raise RegisterError('invalid_token')
+
+                if not ('openid' in self.token.scope):
+                    logger.error('[Register] Missing openid scope.')
+                    raise RegisterError('insufficient_scope')
+            
+            except Token.DoesNotExist:
+                #logger.error('[UserInfo] Token does not exist: %s', self.params.access_token)
+                raise RegisterError('invalid_token')
+         
+        # Has the user provided redirect URIs in JSON?
+        if self.params.redirecturis is None:
+            raise RegisterError('invalid_request') 
+        
+    def create_response_dic(self):
+        """
+        Create a dictionary with client_id, client_secret, and 
+        client_secret_expires_at (set to 0 at this point)
+        See: https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+        """
+        client = create_client(redirect_uris=self.params.redirecturis, 
+                               name=self.params.name, 
+                               response_type=self.params.response_types)
+        
+        client.save()
+        # At this point, no support for client secret expiration so
+        # we return 0 meaning that it doesn't expire
+        dic = {
+            'id': client.client_id, 
+            'secret': client.client_secret,
+            'client_secret_expires_at': '0'
+        }
+
+        return dic
+
+    @classmethod
+    def response(cls, dic):
+        response = JsonResponse(dic, status=200)
+        response['Cache-Control'] = 'no-store'
+        response['Pragma'] = 'no-cache'
+
+        return response
+
+    @classmethod
+    def error_response(cls, code, description, status):
+        response = HttpResponse(status=status)
+        response['WWW-Authenticate'] = 'error="{0}", error_description="{1}"'.format(code, description)
+
+        return response
+

--- a/oidc_provider/lib/errors.py
+++ b/oidc_provider/lib/errors.py
@@ -1,3 +1,4 @@
+import code
 try:
     from urllib.parse import quote
 except ImportError:
@@ -156,6 +157,30 @@ class UserInfoError(Exception):
 
     def __init__(self, code):
 
+        self.code = code
+        error_tuple = self._errors.get(code, ('', ''))
+        self.description = error_tuple[0]
+        self.status = error_tuple[1]
+
+class RegisterError(Exception):
+    _errors = {
+    # https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError 
+    # https://tools.ietf.org/html/rfc6749#section-5.2
+            'invalid_request': (
+            'The request is otherwise malformed', 400
+        ),   
+            'invalid_token': (
+            'The access token provided is expired, revoked, malformed, '
+            'or invalid for other reasons', 401
+        ),
+            'insufficient_scope': (
+            'The request requires higher privileges than provided by '
+            'the access token', 403
+        ),             
+    }
+    
+    def __init__(self, code):
+        
         self.code = code
         error_tuple = self._errors.get(code, ('', ''))
         self.description = error_tuple[0]

--- a/oidc_provider/lib/utils/register.py
+++ b/oidc_provider/lib/utils/register.py
@@ -1,0 +1,25 @@
+from datetime import timedelta
+import time
+import uuid
+
+from django.utils import timezone
+from hashlib import md5
+
+from oidc_provider.lib.utils.common import get_issuer, get_rsa_key
+from oidc_provider.models import *
+from oidc_provider import settings
+
+from django.db.models import Max
+ 
+def create_client(redirect_uris=None, name=None, response_type = 'code'):
+    client = Client()
+    client._redirect_uris = redirect_uris
+    client.response_type = response_type    
+    client.name = name
+    client.client_id = uuid.uuid4().hex
+    client.client_secret = uuid.uuid4().hex
+    
+    return client
+    
+    
+

--- a/oidc_provider/settings.py
+++ b/oidc_provider/settings.py
@@ -94,7 +94,24 @@ class DefaultSettings(object):
         Expressed in seconds.
         """
         return 60*60
-
+    
+    @property
+    def REGISTRATION_ENDPOINT_ENABLED(self):
+        """
+        OPTIONAL. True if dynamic client registration endpoint is enabled
+        https://openid.net/specs/openid-connect-registration-1_0.html#ClientRegistration
+        """
+        return True
+     
+    @property
+    def REGISTRATION_ENDPOINT_REQ_TOKEN(self):
+        """
+        OPTIONAL. True if client registration requires bearer (access) token.
+        False if clients can be dynamically registered without authentication
+        http://tools.ietf.org/html/rfc6750#section-2.1
+        """
+        return True
+        
 default_settings = DefaultSettings()
 
 

--- a/oidc_provider/urls.py
+++ b/oidc_provider/urls.py
@@ -9,6 +9,8 @@ urlpatterns = patterns('',
     url(r'^token/$', csrf_exempt(TokenView.as_view()), name='token'),
     url(r'^userinfo/$', csrf_exempt(userinfo), name='userinfo'),
     url(r'^logout/$', LogoutView.as_view(), name='logout'),
+    url(r'^register/$', csrf_exempt(RegisterView.as_view()), name='register'),
+
 
     url(r'^\.well-known/openid-configuration/$', ProviderInfoView.as_view(), name='provider_info'),
     url(r'^jwks/$', JwksView.as_view(), name='jwks'),

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -14,8 +14,10 @@ from jwkest import long_to_base64
 from oidc_provider.lib.endpoints.authorize import *
 from oidc_provider.lib.endpoints.token import *
 from oidc_provider.lib.endpoints.userinfo import *
+
 from oidc_provider.lib.errors import *
 from oidc_provider.lib.utils.common import get_issuer, get_rsa_key
+from oidc_provider.lib.endpoints.register import RegisterEndpoint
 
 
 logger = logging.getLogger(__name__)
@@ -201,3 +203,21 @@ class LogoutView(View):
     def get(self, request, *args, **kwargs):
         # We should actually verify if the requested redirect URI is safe
         return logout(request, next_page=request.GET.get('post_logout_redirect_uri'))
+
+
+class RegisterView(View):
+    def post(self, request, *args, **kwargs):
+        
+        register = RegisterEndpoint(request)
+        
+        try:
+            register.validate_params()
+            dic = register.create_response_dic()
+            return register.response(dic)
+        
+        except (RegisterError) as error:
+            return RegisterEndpoint.error_response(
+            error.code,
+            error.description,
+            error.status)
+        


### PR DESCRIPTION
Added dynamic registration endpoint.  There are two additional variables in settings. REGISTRATION_ENDPOINT_ENABLED is set to True if the endpoint should be enabled at all, and false if not.  REGISTRATION_ENDPOINT_REQ_TOKEN is set to True if the endpoint requires that a user trying to register a new client authenticate with a valid access token.  Note: I commented some code out in claims.py because it was breaking under Python 2.7 with the recent database setup.