### PR TITLE
Make (user, client) unique on UserConsent

### DIFF
--- a/oidc_provider/migrations/0006_unique_user_client.py
+++ b/oidc_provider/migrations/0006_unique_user_client.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oidc_provider', '0005_token_refresh_token'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='userconsent',
+            unique_together=set([('user', 'client')]),
+        ),
+    ]

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -89,5 +89,5 @@ class Token(BaseCodeTokenModel):
 
 
 class UserConsent(BaseCodeTokenModel):
-
-    pass
+    class Meta:
+        unique_together = ('user', 'client')


### PR DESCRIPTION
The code assumes this combination is unique with the `get` and `get_or_create`
calls.

In our project we got a user that had two UserContents in the database. This gave exceptions because the `get_or_create` then fails because there are two results. Better to give an exception when adding it to the database.