### PR TITLE
Allowing urls without slashes

### DIFF
--- a/oidc_provider/urls.py
+++ b/oidc_provider/urls.py
@@ -5,12 +5,12 @@ from oidc_provider.views import *
 
 urlpatterns = patterns('',
 
-    url(r'^authorize/$', AuthorizeView.as_view(), name='authorize'),
-    url(r'^token/$', csrf_exempt(TokenView.as_view()), name='token'),
-    url(r'^userinfo/$', csrf_exempt(userinfo), name='userinfo'),
-    url(r'^logout/$', LogoutView.as_view(), name='logout'),
+    url(r'^authorize/?$', AuthorizeView.as_view(), name='authorize'),
+    url(r'^token/?$', csrf_exempt(TokenView.as_view()), name='token'),
+    url(r'^userinfo/?$', csrf_exempt(userinfo), name='userinfo'),
+    url(r'^logout/?$', LogoutView.as_view(), name='logout'),
 
-    url(r'^\.well-known/openid-configuration/$', ProviderInfoView.as_view(), name='provider_info'),
-    url(r'^jwks/$', JwksView.as_view(), name='jwks'),
+    url(r'^\.well-known/openid-configuration/?$', ProviderInfoView.as_view(), name='provider_info'),
+    url(r'^jwks/?$', JwksView.as_view(), name='jwks'),
 
 )


### PR DESCRIPTION
The docs seem to point toward the authorize endpoint allowing no slash but this doesn't seem to be the case. 
At any rate, I think it's useful to allow both with and without the trailing slash.

If you're not interested in allowing it I can remove this PR and I will update that particular line in the docs instead.