### PR TITLE
Revert "Allowing urls without slashes"

### DIFF
--- a/oidc_provider/urls.py
+++ b/oidc_provider/urls.py
@@ -5,12 +5,12 @@ from oidc_provider.views import *
 
 urlpatterns = patterns('',
 
-    url(r'^authorize/?$', AuthorizeView.as_view(), name='authorize'),
-    url(r'^token/?$', csrf_exempt(TokenView.as_view()), name='token'),
-    url(r'^userinfo/?$', csrf_exempt(userinfo), name='userinfo'),
-    url(r'^logout/?$', LogoutView.as_view(), name='logout'),
+    url(r'^authorize/$', AuthorizeView.as_view(), name='authorize'),
+    url(r'^token/$', csrf_exempt(TokenView.as_view()), name='token'),
+    url(r'^userinfo/$', csrf_exempt(userinfo), name='userinfo'),
+    url(r'^logout/$', LogoutView.as_view(), name='logout'),
 
-    url(r'^\.well-known/openid-configuration/?$', ProviderInfoView.as_view(), name='provider_info'),
-    url(r'^jwks/?$', JwksView.as_view(), name='jwks'),
+    url(r'^\.well-known/openid-configuration/$', ProviderInfoView.as_view(), name='provider_info'),
+    url(r'^jwks/$', JwksView.as_view(), name='jwks'),
 
 )


### PR DESCRIPTION
Reverts juanifioren/django-oidc-provider#62

Why? Because when someone POST the url should have the endlash.