### PR TITLE
Fix #72 get_issuer() returns a wrong value

### DIFF
--- a/oidc_provider/lib/utils/common.py
+++ b/oidc_provider/lib/utils/common.py
@@ -21,7 +21,7 @@ def get_issuer():
     """
     site_url = settings.get('SITE_URL')
     path = reverse('oidc_provider:provider_info') \
-        .split('/.well-known/openid-configuration/')[0]
+        .split('/.well-known/openid-configuration')[0]
     issuer = site_url + path
 
     return issuer

--- a/oidc_provider/tests/test_utils.py
+++ b/oidc_provider/tests/test_utils.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.test import TestCase
+
+from oidc_provider.lib.utils.common import get_issuer
+
+
+class CommonTest(TestCase):
+    """
+    Test cases for common utils.
+    """
+    def test_get_issuer(self):
+        issuer = get_issuer()
+        self.assertEqual(issuer, settings.SITE_URL + '/openid')


### PR DESCRIPTION
This PR proposes a fix for https://github.com/juanifioren/django-oidc-provider/issues/72 and add a test for the get_issuer() function.

I'm not sure if the test case is necessary or is in the right place, but if you want I can remove it because the split issue seems to be just a typo.

If you have questions or feedback, please let me know.