### PR TITLE
add docker file to the example project

### DIFF
--- a/example_project/Dockerfile
+++ b/example_project/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:2-onbuild
+
+RUN [ "python", "manage.py", "migrate" ]
+RUN [ "python", "manage.py", "creatersakey" ]
+EXPOSE 8000
+CMD [ "python", "manage.py", "runserver", "0.0.0.0:8000" ]

--- a/example_project/README.md
+++ b/example_project/README.md
@@ -29,6 +29,20 @@ $ python manage.py runserver
 
 Open your browser and go to `http://localhost:8000`. Voilà!
 
+## Or Use Docker
+
+Build the container first.
+```
+docker build -t django-oidc-provider .
+```
+
+Run the container next.
+```
+docker run -d -p 8000:8000 django-oidc-provider
+```
+
+Open your browser and go to `http://localhost:8000`. Voilà!
+
 ## Install package for development
 
 After you run `pip install -r requirements.txt`.


### PR DESCRIPTION
This adds a Dockerfile with the example project to show how django oidc would work in that environment.