### PR TITLE
Add py35 environment to tox/travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,15 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 env:
   - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
+matrix:
+  exclude:
+    - python: "3.5"
+      env: DJANGO=1.7
 install:
   - pip install -q django==$DJANGO
   - pip install -e .

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 
 envlist=
-    clean,py{27,34}-django{17,18,19},stats
+    clean,py{27,34}-django{17,18,19},py35-django{18,19},stats
 
 [testenv]
 


### PR DESCRIPTION
Django v1.7 is not compatible with Python v3.5 so it is not tested.