### PR TITLE
Add warning if 'bearer', not 'Bearer', token received

### DIFF
--- a/oidc_provider/lib/utils/oauth2.py
+++ b/oidc_provider/lib/utils/oauth2.py
@@ -19,7 +19,12 @@ def extract_access_token(request):
     Return a string.
     """
     auth_header = request.META.get('HTTP_AUTHORIZATION', '')
-
+    if auth_header.startswith('bearer'):  # lowercase
+        warnings.warn(
+            "Client passes 'bearer' token, which is lowercase and breaks standarts for {}".format(
+                request.path_info
+            )
+        )
     if re.compile('^Bearer\s{1}.+$').match(auth_header):
         access_token = auth_header.split()[1]
     else:


### PR DESCRIPTION
Hi! not sure you consider it important, but for example pyoidc library (before next version at least, if they accept the PR) sends wrong value... And this warning will save someone's time by implicitly show what happened instead of just "bad token received: " message.

Spec says that word shall be "Bearer" and doesn't say anything about case, so assuming it's verbatim and capitalized.