### PR TITLE
JWT deps support for pyjwkest and python-jose #103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### [0.3.6] - 2016-07-07
 
+##### Added
+- Support for python-jose in addition to pyjwkest.
+
 ##### Changed
 - OIDC_USERINFO setting.
 

--- a/docs/sections/installation.rst
+++ b/docs/sections/installation.rst
@@ -14,9 +14,19 @@ Quick Installation
 
 If you want to get started fast see our ``/example_project`` folder.
 
-Install the package using pip::
+OIDC Provider relies on a JWT implementation, and supports pyjwkest and
+python-jose. Under CPython, pyjwkest uses Cryptodome, while python-jose uses
+PyCrypto.  PyCrypto and Cryptodome must not both be installed, as they are
+incompatible. If your project already uses one of these crypto libraries, you
+may prefer one JWT implementation over the other.
 
-    $ pip install django-oidc-provider
+Install the package with pyjwkest using pip::
+
+    $ pip install django-oidc-provider[pyjwkest]
+
+Or, if you prefer to use python-jose:
+
+    $ pip install django-oidc-provider[jose]
 
 Add it to your apps::
 

--- a/oidc_provider/lib/jwt_compat.py
+++ b/oidc_provider/lib/jwt_compat.py
@@ -1,50 +1,106 @@
+import hashlib, json
+
 from Crypto.PublicKey import RSA
 from Crypto.PublicKey.RSA import importKey
-from jwkest.jwk import KEYS
-from jwkest.jwk import RSAKey as jwk_RSAKey
-from jwkest.jwk import SYMKey
-from jwkest.jws import JWS
-from jwkest.jwt import JWT
-from jwkest import long_to_base64 as l_to_b64
+
+SUPPORT_ALGS = ['HS256', 'RS256']
+
+HAS_JWKEST = HAS_JOSE = False
+try:
+    import jwkest.jwk
+    import jwkest.jws
+    import jwkest.jwt
+
+    HAS_JWKEST = True
+
+    def load_keys(public_keys):
+        jwkest_keys = jwkest.jwk.KEYS()
+        jwkest_keys.load_dict(public_keys)
+        return jwkest_keys
+
+    def from_model_keys(model_keys):
+        return [jwkest.jwk.RSAKey(key=importKey(model_key.key), kid=model_key.kid)
+            for model_key in model_keys]
+
+    def from_client_secret(secret, alg):
+        return jwkest.jwk.SYMKey(key=secret, alg=alg)
+
+    def get_kid(rsa_key):
+        return rsa_key.kid
+except ImportError:
+    import jose.jws
+    import jose.jwt
+
+    HAS_JOSE = True
+
+    def load_keys(public_keys):
+        return [key[0] for key in public_keys.values()]
+
+    def from_model_keys(model_keys):
+        return [importKey(model_key.key) for model_key in model_keys]
+
+    def from_client_secret(secret, alg):
+        return secret
+
+    def get_kid(rsa_key):
+        pem = rsa_key.exportKey('PEM')
+        return hashlib.md5(pem).hexdigest()
+
+except ImportError:
+    raise ImportError("Either python-jose or pyjwkest is required.")
+
+from oidc_provider.lib.utils.common import long_to_base64
 
 def generate_key(bits):
     key = RSA.generate(bits)
     return key.exportKey('PEM').decode('utf8')
-
-def load_keys(public_keys):
-    SIGKEYS = KEYS()
-    SIGKEYS.load_dict(public_keys)
-    return SIGKEYS
-
-def to_rsa_keys(model_keys):
-    return [jwk_RSAKey(key=importKey(model_key.key), kid=model_key.kid)
-        for model_key in model_keys]
 
 def to_public_key(rsa_key):
     return {
         'kty': 'RSA',
         'alg': 'RS256',
         'use': 'sig',
-        'kid': rsa_key.kid,
+        'kid': get_kid(rsa_key),
         'n': long_to_base64(rsa_key.n),
         'e': long_to_base64(rsa_key.e)
     }
 
 def sign_payload(alg, keys, payload):
     if alg == 'RS256':
-        keys = to_rsa_keys(keys)
+        keys = from_model_keys(keys)
     elif alg == 'HS256':
-        keys = [SYMKey(key=keys[0], alg=alg)]
+        keys = [from_client_secret(keys[0])]
+    else:
+        raise ValueError("Unsupported algorithm %s" % alg)
 
-    _jws = JWS(payload, alg=alg)
-
-    return _jws.sign_compact(keys)
+    if HAS_JWKEST:
+        _jws = jwkest.jws.JWS(payload, alg=alg)
+        return _jws.sign_compact(keys)
+    else: # has jose
+        return jose.jwt.encode(payload, keys[0], algorithm=alg)
 
 def unpack_payload(message):
-    return JWT().unpack(message.encode('utf-8')).payload()
+    if HAS_JWKEST:
+        return jwkest.jwt.JWT().unpack(message.encode('utf-8')).payload()
+    else:
+        parts = jose.jws._load(message.encode('utf-8'))
+        if not len(parts) == 4:
+            raise ValueError("jose jws._load has changed")
+        return json.loads(parts[1])
 
 def verify_payload(message, keys):
-    return JWS().verify_compact(message.encode('utf-8'), keys)
+    if HAS_JWKEST:
+        return jwkest.jws.JWS().verify_compact(message.encode('utf-8'), keys)
+    else:
+        for key in keys:
+            try:
+                payload = jose.jws.verify(message, key, SUPPORT_ALGS)
+            except jose.JWSError:
+                pass
+            try:
+                return json.loads(payload)
+            except ValueError:
+                raise JWSError("Non-JSON payload")
+        else:
+            raise JWSError('Signature verification failed.')
 
-def long_to_base64(n):
-    return l_to_b64(n)

--- a/oidc_provider/lib/jwt_compat.py
+++ b/oidc_provider/lib/jwt_compat.py
@@ -1,4 +1,4 @@
-import hashlib, json
+import base64, hashlib, json, struct
 
 from Crypto.PublicKey import RSA
 from Crypto.PublicKey.RSA import importKey
@@ -6,92 +6,94 @@ from Crypto.PublicKey.RSA import importKey
 SUPPORT_ALGS = ['HS256', 'RS256']
 
 HAS_JWKEST = HAS_JOSE = False
-try:
-    import jwkest.jwk
-    import jwkest.jws
-    import jwkest.jwt
 
-    HAS_JWKEST = True
+def long_to_base64(n):
+    _bytes = []
+    while n:
+        n, r = divmod(n, 256)
+        _bytes.append(r)
+    _bytes.reverse()
+    data = struct.pack('%sB' % len(_bytes), *_bytes)
+    if not len(data):
+        data = '\x00'
+    s = base64.urlsafe_b64encode(data).rstrip(b'=')
+    return s.decode("ascii")
 
-    def load_keys(public_keys):
+class AdapterBase(object):
+    def sign_payload(self, alg, keys, payload):
+        if alg == 'RS256':
+            keys = self.from_model_keys(keys)
+        elif alg == 'HS256':
+            keys = [self.from_client_secret(keys[0])]
+        else:
+            raise ValueError("Unsupported algorithm %s" % alg)
+
+        return self._sign(alg, keys, payload)
+
+    def generate_key(self, bits):
+        key = RSA.generate(bits)
+        return key.exportKey('PEM').decode('utf8')
+
+    def to_public_key(self, rsa_key):
+        return {
+            'kty': 'RSA',
+            'alg': 'RS256',
+            'use': 'sig',
+            'kid': self.get_kid(rsa_key),
+            'n': long_to_base64(rsa_key.n),
+            'e': long_to_base64(rsa_key.e)
+        }
+
+class JwkestAdapter(AdapterBase):
+    def load_keys(self, public_keys):
         jwkest_keys = jwkest.jwk.KEYS()
         jwkest_keys.load_dict(public_keys)
         return jwkest_keys
 
-    def from_model_keys(model_keys):
+    def from_model_keys(self, model_keys):
         return [jwkest.jwk.RSAKey(key=importKey(model_key.key), kid=model_key.kid)
             for model_key in model_keys]
 
-    def from_client_secret(secret, alg):
+    def from_client_secret(self, secret, alg):
         return jwkest.jwk.SYMKey(key=secret, alg=alg)
 
-    def get_kid(rsa_key):
+    def get_kid(self, rsa_key):
         return rsa_key.kid
-except ImportError:
-    import jose.jws
-    import jose.jwt
 
-    HAS_JOSE = True
+    def _sign(self, alg, keys, payload):
+        _jws = jwkest.jws.JWS(payload, alg=alg)
+        return _jws.sign_compact(keys)
 
-    def load_keys(public_keys):
+    def unpack_payload(self, message):
+        return jwkest.jwt.JWT().unpack(message.encode('utf-8')).payload()
+
+    def verify_payload(self, message, keys):
+        return jwkest.jws.JWS().verify_compact(message.encode('utf-8'), keys)
+
+class JoseAdapter(AdapterBase):
+    def load_keys(self, public_keys):
         return [key[0] for key in public_keys.values()]
 
-    def from_model_keys(model_keys):
+    def from_model_keys(self, model_keys):
         return [importKey(model_key.key) for model_key in model_keys]
 
-    def from_client_secret(secret, alg):
+    def from_client_secret(self, secret, alg):
         return secret
 
-    def get_kid(rsa_key):
+    def get_kid(self, rsa_key):
         pem = rsa_key.exportKey('PEM')
         return hashlib.md5(pem).hexdigest()
 
-except ImportError:
-    raise ImportError("Either python-jose or pyjwkest is required.")
-
-from oidc_provider.lib.utils.common import long_to_base64
-
-def generate_key(bits):
-    key = RSA.generate(bits)
-    return key.exportKey('PEM').decode('utf8')
-
-def to_public_key(rsa_key):
-    return {
-        'kty': 'RSA',
-        'alg': 'RS256',
-        'use': 'sig',
-        'kid': get_kid(rsa_key),
-        'n': long_to_base64(rsa_key.n),
-        'e': long_to_base64(rsa_key.e)
-    }
-
-def sign_payload(alg, keys, payload):
-    if alg == 'RS256':
-        keys = from_model_keys(keys)
-    elif alg == 'HS256':
-        keys = [from_client_secret(keys[0])]
-    else:
-        raise ValueError("Unsupported algorithm %s" % alg)
-
-    if HAS_JWKEST:
-        _jws = jwkest.jws.JWS(payload, alg=alg)
-        return _jws.sign_compact(keys)
-    else: # has jose
+    def _sign(self, alg, keys, payload):
         return jose.jwt.encode(payload, keys[0], algorithm=alg)
 
-def unpack_payload(message):
-    if HAS_JWKEST:
-        return jwkest.jwt.JWT().unpack(message.encode('utf-8')).payload()
-    else:
+    def unpack_payload(self, message):
         parts = jose.jws._load(message.encode('utf-8'))
         if not len(parts) == 4:
             raise ValueError("jose jws._load has changed")
         return json.loads(parts[1])
 
-def verify_payload(message, keys):
-    if HAS_JWKEST:
-        return jwkest.jws.JWS().verify_compact(message.encode('utf-8'), keys)
-    else:
+    def verify_payload(self, message, keys):
         for key in keys:
             try:
                 payload = jose.jws.verify(message, key, SUPPORT_ALGS)
@@ -104,3 +106,21 @@ def verify_payload(message, keys):
         else:
             raise JWSError('Signature verification failed.')
 
+try:
+    import jwkest.jwk
+    import jwkest.jws
+    import jwkest.jwt
+
+    HAS_JWKEST = True
+
+    adapter = JwkestAdapter()
+
+except ImportError:
+    import jose.jws
+    import jose.jwt
+
+    HAS_JOSE = True
+    adapter = JoseAdapter()
+
+except ImportError:
+    raise ImportError("Either python-jose or pyjwkest is required.")

--- a/oidc_provider/lib/jwt_compat.py
+++ b/oidc_provider/lib/jwt_compat.py
@@ -1,0 +1,50 @@
+from Crypto.PublicKey import RSA
+from Crypto.PublicKey.RSA import importKey
+from jwkest.jwk import KEYS
+from jwkest.jwk import RSAKey as jwk_RSAKey
+from jwkest.jwk import SYMKey
+from jwkest.jws import JWS
+from jwkest.jwt import JWT
+from jwkest import long_to_base64 as l_to_b64
+
+def generate_key(bits):
+    key = RSA.generate(bits)
+    return key.exportKey('PEM').decode('utf8')
+
+def load_keys(public_keys):
+    SIGKEYS = KEYS()
+    SIGKEYS.load_dict(public_keys)
+    return SIGKEYS
+
+def to_rsa_keys(model_keys):
+    return [jwk_RSAKey(key=importKey(model_key.key), kid=model_key.kid)
+        for model_key in model_keys]
+
+def to_public_key(rsa_key):
+    return {
+        'kty': 'RSA',
+        'alg': 'RS256',
+        'use': 'sig',
+        'kid': rsa_key.kid,
+        'n': long_to_base64(rsa_key.n),
+        'e': long_to_base64(rsa_key.e)
+    }
+
+def sign_payload(alg, keys, payload):
+    if alg == 'RS256':
+        keys = to_rsa_keys(keys)
+    elif alg == 'HS256':
+        keys = [SYMKey(key=keys[0], alg=alg)]
+
+    _jws = JWS(payload, alg=alg)
+
+    return _jws.sign_compact(keys)
+
+def unpack_payload(message):
+    return JWT().unpack(message.encode('utf-8')).payload()
+
+def verify_payload(message, keys):
+    return JWS().verify_compact(message.encode('utf-8'), keys)
+
+def long_to_base64(n):
+    return l_to_b64(n)

--- a/oidc_provider/lib/utils/common.py
+++ b/oidc_provider/lib/utils/common.py
@@ -82,15 +82,3 @@ def default_idtoken_processing_hook(id_token, user):
     :rtype dict
     """
     return id_token
-
-def long_to_base64(n):
-    _bytes = []
-    while n:
-        n, r = divmod(n, 256)
-        _bytes.append(r)
-    _bytes.reverse()
-    data = struct.pack('%sB' % len(_bytes), *_bytes)
-    if not len(data):
-        data = '\x00'
-    s = base64.urlsafe_b64encode(data).rstrip(b'=')
-    return s.decode("ascii")

--- a/oidc_provider/lib/utils/common.py
+++ b/oidc_provider/lib/utils/common.py
@@ -1,3 +1,5 @@
+import base64, struct
+
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 
@@ -80,3 +82,15 @@ def default_idtoken_processing_hook(id_token, user):
     :rtype dict
     """
     return id_token
+
+def long_to_base64(n):
+    _bytes = []
+    while n:
+        n, r = divmod(n, 256)
+        _bytes.append(r)
+    _bytes.reverse()
+    data = struct.pack('%sB' % len(_bytes), *_bytes)
+    if not len(data):
+        data = '\x00'
+    s = base64.urlsafe_b64encode(data).rstrip(b'=')
+    return s.decode("ascii")

--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -3,7 +3,7 @@ import time
 import uuid
 
 from django.utils import timezone
-from oidc_provider.lib import jwt_compat
+from oidc_provider.lib.jwt_compat import adapter
 from oidc_provider.lib.utils.common import get_issuer
 from oidc_provider.models import *
 from oidc_provider import settings
@@ -67,7 +67,7 @@ def encode_id_token(payload, client):
     else:
         raise Exception('Unsupported key algorithm.')
 
-    return jwt_compat.sign_payload(alg, keys, payload)
+    return adapter.sign_payload(alg, keys, payload)
 
 
 def create_token(user, client, id_token_dic, scope):

--- a/oidc_provider/management/commands/creatersakey.py
+++ b/oidc_provider/management/commands/creatersakey.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            rsakey = RSAKey(key=jwt_compat.generate_key(1024))
+            rsakey = RSAKey(key=jwt_compat.generate_key(1024).decode('utf-8'))
             rsakey.save()
             self.stdout.write(u'RSA key successfully created with kid: {0}'.format(rsakey.kid))
         except Exception as e:

--- a/oidc_provider/management/commands/creatersakey.py
+++ b/oidc_provider/management/commands/creatersakey.py
@@ -1,8 +1,8 @@
 import os
 
-from Crypto.PublicKey import RSA
 from django.core.management.base import BaseCommand
 
+from oidc_provider.lib import jwt_compat
 from oidc_provider import settings
 from oidc_provider.models import RSAKey
 
@@ -12,8 +12,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            key = RSA.generate(1024)
-            rsakey = RSAKey(key=key.exportKey('PEM').decode('utf8'))
+            rsakey = RSAKey(key=jwt_compat.generate_key(1024))
             rsakey.save()
             self.stdout.write(u'RSA key successfully created with kid: {0}'.format(rsakey.kid))
         except Exception as e:

--- a/oidc_provider/management/commands/creatersakey.py
+++ b/oidc_provider/management/commands/creatersakey.py
@@ -2,7 +2,7 @@ import os
 
 from django.core.management.base import BaseCommand
 
-from oidc_provider.lib import jwt_compat
+from oidc_provider.lib.jwt_compat import adapter
 from oidc_provider import settings
 from oidc_provider.models import RSAKey
 
@@ -12,7 +12,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            rsakey = RSAKey(key=jwt_compat.generate_key(1024).decode('utf-8'))
+            rsakey = RSAKey(key=adapter.generate_key(1024).decode('utf-8'))
             rsakey.save()
             self.stdout.write(u'RSA key successfully created with kid: {0}'.format(rsakey.kid))
         except Exception as e:

--- a/oidc_provider/tests/test_token_endpoint.py
+++ b/oidc_provider/tests/test_token_endpoint.py
@@ -309,7 +309,11 @@ class TokenTestCase(TestCase):
         the JOSE Header.
         """
         SIGKEYS = self._get_keys()
-        RSAKEYS = [ k for k in SIGKEYS if k.kty == 'RSA' ]
+
+        if jwt_compat.HAS_JWKEST:
+            RSAKEYS = [ k for k in SIGKEYS if k.kty == 'RSA' ]
+        else:
+            RSAKEYS = [ k for k in SIGKEYS if k['kty'] == 'RSA' ]
 
         code = self._create_code()
 

--- a/oidc_provider/tests/test_token_endpoint.py
+++ b/oidc_provider/tests/test_token_endpoint.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 
 from mock import patch
 
-from oidc_provider.lib import jwt_compat
+from oidc_provider.lib.jwt_compat import adapter, HAS_JWKEST
 from oidc_provider.lib.utils.token import *
 from oidc_provider.tests.app.utils import *
 from oidc_provider.views import *
@@ -95,7 +95,7 @@ class TokenTestCase(TestCase):
         request = self.factory.get(reverse('oidc_provider:jwks'))
         response = JwksView.as_view()(request)
         jwks_dic = json.loads(response.content.decode('utf-8'))
-        return jwt_compat.load_keys(jwks_dic)
+        return adapter.load_keys(jwks_dic)
 
     def _get_userinfo(self, access_token):
         url = reverse('oidc_provider:userinfo')
@@ -119,7 +119,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
         response_dic = json.loads(response.content.decode('utf-8'))
 
-        id_token = jwt_compat.verify_payload(response_dic['id_token'].encode('utf-8'), SIGKEYS)
+        id_token = adapter.verify_payload(response_dic['id_token'].encode('utf-8'), SIGKEYS)
 
         token = Token.objects.get(user=self.user)
         self.assertEqual(response_dic['access_token'], token.access_token)
@@ -146,7 +146,7 @@ class TokenTestCase(TestCase):
             response = self._post_request(post_data)
 
         response_dic1 = json.loads(response.content.decode('utf-8'))
-        id_token1 = jwt_compat.verify_payload(response_dic1['id_token'], SIGKEYS)
+        id_token1 = adapter.verify_payload(response_dic1['id_token'], SIGKEYS)
 
         # Use refresh token to obtain new token
         post_data = self._refresh_token_post_data(response_dic1['refresh_token'])
@@ -155,7 +155,7 @@ class TokenTestCase(TestCase):
             response = self._post_request(post_data)
 
         response_dic2 = json.loads(response.content.decode('utf-8'))
-        id_token2 = jwt_compat.verify_payload(response_dic2['id_token'], SIGKEYS)
+        id_token2 = adapter.verify_payload(response_dic2['id_token'], SIGKEYS)
 
         self.assertNotEqual(response_dic1['id_token'], response_dic2['id_token'])
         self.assertNotEqual(response_dic1['access_token'], response_dic2['access_token'])
@@ -287,7 +287,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('nonce'), FAKE_NONCE)
 
@@ -298,7 +298,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
         response_dic = json.loads(response.content.decode('utf-8'))
 
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('nonce'), None)
 
@@ -310,7 +310,7 @@ class TokenTestCase(TestCase):
         """
         SIGKEYS = self._get_keys()
 
-        if jwt_compat.HAS_JWKEST:
+        if HAS_JWKEST:
             RSAKEYS = [ k for k in SIGKEYS if k.kty == 'RSA' ]
         else:
             RSAKEYS = [ k for k in SIGKEYS if k['kty'] == 'RSA' ]
@@ -322,7 +322,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
         response_dic = json.loads(response.content.decode('utf-8'))
 
-        id_token = jwt_compat.verify_payload(response_dic['id_token'], RSAKEYS)
+        id_token = adapter.verify_payload(response_dic['id_token'], RSAKEYS)
 
     @override_settings(OIDC_IDTOKEN_SUB_GENERATOR='oidc_provider.tests.app.utils.fake_sub_generator')
     def test_custom_sub_generator(self):
@@ -336,7 +336,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('sub'), self.user.email)
 
@@ -352,7 +352,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -373,7 +373,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -394,7 +394,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -416,7 +416,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -441,7 +441,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
+        id_token = adapter.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)

--- a/oidc_provider/tests/test_token_endpoint.py
+++ b/oidc_provider/tests/test_token_endpoint.py
@@ -7,10 +7,10 @@ except ImportError:
 from django.core.management import call_command
 from django.test import RequestFactory, override_settings
 from django.test import TestCase
-from jwkest.jwk import KEYS
-from jwkest.jwt import JWT
+
 from mock import patch
 
+from oidc_provider.lib import jwt_compat
 from oidc_provider.lib.utils.token import *
 from oidc_provider.tests.app.utils import *
 from oidc_provider.views import *
@@ -95,9 +95,7 @@ class TokenTestCase(TestCase):
         request = self.factory.get(reverse('oidc_provider:jwks'))
         response = JwksView.as_view()(request)
         jwks_dic = json.loads(response.content.decode('utf-8'))
-        SIGKEYS = KEYS()
-        SIGKEYS.load_dict(jwks_dic)
-        return SIGKEYS
+        return jwt_compat.load_keys(jwks_dic)
 
     def _get_userinfo(self, access_token):
         url = reverse('oidc_provider:userinfo')
@@ -121,7 +119,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
         response_dic = json.loads(response.content.decode('utf-8'))
 
-        id_token = JWS().verify_compact(response_dic['id_token'].encode('utf-8'), SIGKEYS)
+        id_token = jwt_compat.verify_payload(response_dic['id_token'].encode('utf-8'), SIGKEYS)
 
         token = Token.objects.get(user=self.user)
         self.assertEqual(response_dic['access_token'], token.access_token)
@@ -148,7 +146,7 @@ class TokenTestCase(TestCase):
             response = self._post_request(post_data)
 
         response_dic1 = json.loads(response.content.decode('utf-8'))
-        id_token1 = JWS().verify_compact(response_dic1['id_token'].encode('utf-8'), SIGKEYS)
+        id_token1 = jwt_compat.verify_payload(response_dic1['id_token'], SIGKEYS)
 
         # Use refresh token to obtain new token
         post_data = self._refresh_token_post_data(response_dic1['refresh_token'])
@@ -157,7 +155,7 @@ class TokenTestCase(TestCase):
             response = self._post_request(post_data)
 
         response_dic2 = json.loads(response.content.decode('utf-8'))
-        id_token2 = JWS().verify_compact(response_dic2['id_token'].encode('utf-8'), SIGKEYS)
+        id_token2 = jwt_compat.verify_payload(response_dic2['id_token'], SIGKEYS)
 
         self.assertNotEqual(response_dic1['id_token'], response_dic2['id_token'])
         self.assertNotEqual(response_dic1['access_token'], response_dic2['access_token'])
@@ -289,7 +287,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('nonce'), FAKE_NONCE)
 
@@ -300,7 +298,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
         response_dic = json.loads(response.content.decode('utf-8'))
 
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('nonce'), None)
 
@@ -320,7 +318,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
         response_dic = json.loads(response.content.decode('utf-8'))
 
-        id_token = JWS().verify_compact(response_dic['id_token'].encode('utf-8'), RSAKEYS)
+        id_token = jwt_compat.verify_payload(response_dic['id_token'], RSAKEYS)
 
     @override_settings(OIDC_IDTOKEN_SUB_GENERATOR='oidc_provider.tests.app.utils.fake_sub_generator')
     def test_custom_sub_generator(self):
@@ -334,7 +332,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('sub'), self.user.email)
 
@@ -350,7 +348,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -371,7 +369,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -392,7 +390,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -414,7 +412,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)
@@ -439,7 +437,7 @@ class TokenTestCase(TestCase):
         response = self._post_request(post_data)
 
         response_dic = json.loads(response.content.decode('utf-8'))
-        id_token = JWT().unpack(response_dic['id_token'].encode('utf-8')).payload()
+        id_token = jwt_compat.unpack_payload(response_dic['id_token'])
 
         self.assertEqual(id_token.get('test_idtoken_processing_hook'), FAKE_RANDOM_STRING)
         self.assertEqual(id_token.get('test_idtoken_processing_hook_user_email'), self.user.email)

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -204,7 +204,7 @@ class JwksView(View):
     def get(self, request, *args, **kwargs):
         dic = dict(keys=[])
 
-        rsa_keys = jwt_compat.to_rsa_keys(RSAKey.objects.all())
+        rsa_keys = jwt_compat.from_model_keys(RSAKey.objects.all())
 
         for rsa_key in rsa_keys:
             public_key = jwt_compat.to_public_key(rsa_key)

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -1,4 +1,3 @@
-from Crypto.PublicKey import RSA
 from django.contrib.auth.views import redirect_to_login, logout
 from django.core.urlresolvers import reverse
 from django.http import JsonResponse
@@ -6,8 +5,9 @@ from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.views.decorators.http import require_http_methods
 from django.views.generic import View
-from jwkest import long_to_base64
 
+
+from oidc_provider.lib import jwt_compat
 from oidc_provider.lib.claims import StandardScopeClaims
 from oidc_provider.lib.endpoints.authorize import *
 from oidc_provider.lib.endpoints.token import *
@@ -204,16 +204,11 @@ class JwksView(View):
     def get(self, request, *args, **kwargs):
         dic = dict(keys=[])
 
-        for rsakey in RSAKey.objects.all():
-            public_key  = RSA.importKey(rsakey.key).publickey()
-            dic['keys'].append({
-                'kty': 'RSA',
-                'alg': 'RS256',
-                'use': 'sig',
-                'kid': rsakey.kid,
-                'n': long_to_base64(public_key.n),
-                'e': long_to_base64(public_key.e),
-            })
+        rsa_keys = jwt_compat.to_rsa_keys(RSAKey.objects.all())
+
+        for rsa_key in rsa_keys:
+            public_key = jwt_compat.to_public_key(rsa_key)
+            dic['keys'].append(public_key)
 
         response = JsonResponse(dic)
         response['Access-Control-Allow-Origin'] = '*'

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.generic import View
 
 
-from oidc_provider.lib import jwt_compat
+from oidc_provider.lib.jwt_compat import adapter
 from oidc_provider.lib.claims import StandardScopeClaims
 from oidc_provider.lib.endpoints.authorize import *
 from oidc_provider.lib.endpoints.token import *
@@ -204,10 +204,10 @@ class JwksView(View):
     def get(self, request, *args, **kwargs):
         dic = dict(keys=[])
 
-        rsa_keys = jwt_compat.from_model_keys(RSAKey.objects.all())
+        rsa_keys = adapter.from_model_keys(RSAKey.objects.all())
 
         for rsa_key in rsa_keys:
-            public_key = jwt_compat.to_public_key(rsa_key)
+            public_key = adapter.to_public_key(rsa_key)
             dic['keys'].append(public_key)
 
         response = JsonResponse(dic)

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ setup(
         'pyjwkest==1.1.0',
         'mock==1.3.0',
     ],
-
-    install_requires=[
-        'pyjwkest==1.1.0',
-    ],
+    extras_require={
+        'pyjwkest': ['pyjwkest==1.1.0'],
+        'jose': ['python-jose==1.0.0'],
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 
 envlist=
-    clean,py{27,34}-django{17,18,19},py35-django{18,19},stats
+    clean,py{27,34}-django{17,18,19}-{jwkest,jose},py35-django{18,19},stats
 
 [testenv]
 
@@ -9,6 +9,8 @@ deps =
     django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
     django19: django>=1.9,<2.0
+    jwkest: pyjwkest==1.1.0
+    jose: python-jose==1.0.0
     coverage
     mock
 


### PR DESCRIPTION
I haven't been able to keep requirements-file compat. That is, install with pyjwkest is now 'pip install django-oidc-provider[pyjwkest]' rather than 'pip install django-oidc-provider'. Otherwise, this PR has tests passing in all tox environments (have a look at diff in setup.py and tox.ini).

Given the change in install, I think maybe this would make 0.4.0? Feedback welcome. :)