### PR TITLE
Remove unused import

### DIFF
--- a/oidc_provider/urls.py
+++ b/oidc_provider/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.views.decorators.csrf import csrf_exempt
 from oidc_provider.views import *
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     tests_require=[
         'pyjwkest==1.1.0',
-        'mock==1.3.0',
+        'mock==2.0.0',
     ],
 
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 
 envlist=
-    clean,py{27,34}-django{17,18,19},py35-django{18,19},stats
+    clean,py{27,34}-django{17,18,19,110},py35-django{18,19,110},stats
 
 [testenv]
 
@@ -9,6 +9,7 @@ deps =
     django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
     django19: django>=1.9,<1.10
+    django110: django>=1.10,<1.11
     coverage
     mock
 


### PR DESCRIPTION
Migrations fail for an app running Python 3.5 and Django 1.10 when importing django-oidc-provider via:

```python
from django.conf.urls import url, include

urlpatterns = [
    url(r"^oidc/", include("oidc_provider.urls", namespace="oidc_provider")),
]
```

>   File "/Users/graham/venv/m2-api/lib/python3.5/site-packages/oidc_provider/urls.py", line 1, in <module>
>    from django.conf.urls import patterns, include, url
> ImportError: cannot import name 'patterns'

This PR:
 * removes unused `patterns` import, which fails under Django 1.10 (reference https://docs.djangoproject.com/en/1.10/releases/1.10/#removed-features-1-10)
 * updates mock requirement to latest release
 * adds Django v1.10 to test matrix