### PR TITLE
Fix import in example project

### DIFF
--- a/example_project/myapp/urls.py
+++ b/example_project/myapp/urls.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import views as auth_views
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import TemplateView
 


### PR DESCRIPTION
django.conf.urls.patterns is removed in Django 1.10