### PR TITLE
Make Client available when using OIDC_EXTRA_SCOPE_CLAIMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 ##### Fixed
 - Bug when generating secret_key value using admin.
 
+##### Changed
+- Client is available to OIDC_EXTRA_SCOPE_CLAIMS implementations via `self.client`.
+
+##### Incompatible changes
+- The constructor signature for `ScopeClaims` has changed, it now is called with the `Token` as its single argument.
+
 ### [0.4.1] - 2016-10-03
 
 ##### Changed

--- a/docs/sections/scopesclaims.rst
+++ b/docs/sections/scopesclaims.rst
@@ -96,6 +96,7 @@ Inside your oidc_provider_settings.py file add the following class::
             # self.user - Django user instance.
             # self.userinfo - Dict returned by OIDC_USERINFO function.
             # self.scopes - List of scopes requested.
+            # self.client - Client requesting this claims.
             dic = {
                 'bar': 'Something dynamic here',
             }

--- a/oidc_provider/lib/claims.py
+++ b/oidc_provider/lib/claims.py
@@ -14,10 +14,11 @@ STANDARD_CLAIMS = {
 
 class ScopeClaims(object):
 
-    def __init__(self, user, scopes):
-        self.user = user
+    def __init__(self, token):
+        self.user = token.user
         self.userinfo = settings.get('OIDC_USERINFO', import_str=True)(STANDARD_CLAIMS, self.user)
-        self.scopes = scopes
+        self.scopes = token.scope
+        self.client = token.client
 
     def create_response_dic(self):
         """

--- a/oidc_provider/tests/app/utils.py
+++ b/oidc_provider/tests/app/utils.py
@@ -1,16 +1,19 @@
 import random
 import string
+
+
 try:
     from urlparse import parse_qs, urlsplit
 except ImportError:
     from urllib.parse import parse_qs, urlsplit
 
+from django.utils import timezone
 from django.contrib.auth.models import User
 
 from oidc_provider.models import (
     Client,
     Code,
-)
+    Token)
 
 
 FAKE_NONCE = 'cb584e44c43ed6bd0bc2d9c7e242837d'
@@ -56,6 +59,16 @@ def create_fake_client(response_type, is_public=False):
     client.save()
 
     return client
+
+
+def create_fake_token(user, scopes, client):
+    expires_at = timezone.now() + timezone.timedelta(seconds=60)
+    token = Token(user=user, client=client, expires_at=expires_at)
+    token.scope = scopes
+
+    token.save()
+
+    return token
 
 
 def is_code_valid(url, user, client):

--- a/oidc_provider/tests/test_claims.py
+++ b/oidc_provider/tests/test_claims.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
+
 from oidc_provider.lib.claims import ScopeClaims
-from oidc_provider.tests.app.utils import create_fake_user
+from oidc_provider.tests.app.utils import create_fake_user, create_fake_client, create_fake_token
 
 
 class ClaimsTestCase(TestCase):
@@ -8,7 +9,9 @@ class ClaimsTestCase(TestCase):
     def setUp(self):
         self.user = create_fake_user()
         self.scopes = ['openid', 'address', 'email', 'phone', 'profile']
-        self.scopeClaims = ScopeClaims(self.user, self.scopes)
+        self.client = create_fake_client('code')
+        self.token = create_fake_token(self.user, self.scopes, self.client)
+        self.scopeClaims = ScopeClaims(self.token)
 
     def test_clean_dic(self):
         """ assert that _clean_dic function returns a clean dictionnary

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -162,11 +162,11 @@ def userinfo(request, *args, **kwargs):
         'sub': token.id_token.get('sub'),
     }
 
-    standard_claims = StandardScopeClaims(token.user, token.scope)
+    standard_claims = StandardScopeClaims(token)
     dic.update(standard_claims.create_response_dic())
 
     if settings.get('OIDC_EXTRA_SCOPE_CLAIMS'):
-        extra_claims = settings.get('OIDC_EXTRA_SCOPE_CLAIMS', import_str=True)(token.user, token.scope)
+        extra_claims = settings.get('OIDC_EXTRA_SCOPE_CLAIMS', import_str=True)(token)
         dic.update(extra_claims.create_response_dic())
 
     response = JsonResponse(dic, status=200)


### PR DESCRIPTION
Now it's passed the Token to the ScopeClaims constructor so that it can make Client available to implementors.

Related issue: https://github.com/juanifioren/django-oidc-provider/issues/128