### PR TITLE
Fix a bug that the value of STANDARD_CLAIMS is updated

### DIFF
--- a/oidc_provider/lib/claims.py
+++ b/oidc_provider/lib/claims.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.utils.translation import ugettext as _
 
 from oidc_provider import settings
@@ -16,7 +18,8 @@ class ScopeClaims(object):
 
     def __init__(self, token):
         self.user = token.user
-        self.userinfo = settings.get('OIDC_USERINFO', import_str=True)(STANDARD_CLAIMS, self.user)
+        claims = copy.deepcopy(STANDARD_CLAIMS)
+        self.userinfo = settings.get('OIDC_USERINFO', import_str=True)(claims, self.user)
         self.scopes = token.scope
         self.client = token.client
 

--- a/oidc_provider/tests/test_claims.py
+++ b/oidc_provider/tests/test_claims.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from oidc_provider.lib.claims import ScopeClaims
+from oidc_provider.lib.claims import ScopeClaims, STANDARD_CLAIMS
 from oidc_provider.tests.app.utils import create_fake_user, create_fake_client, create_fake_token
 
 
@@ -12,6 +12,13 @@ class ClaimsTestCase(TestCase):
         self.client = create_fake_client('code')
         self.token = create_fake_token(self.user, self.scopes, self.client)
         self.scopeClaims = ScopeClaims(self.token)
+
+    def test_empty_standard_claims(self):
+        for v in [v for k, v in STANDARD_CLAIMS.items() if k != 'address']:
+            self.assertEqual(v, '')
+
+        for v in STANDARD_CLAIMS['address'].values():
+            self.assertEqual(v, '')
 
     def test_clean_dic(self):
         """ assert that _clean_dic function returns a clean dictionnary


### PR DESCRIPTION
```
======================================================================
FAIL: test_empty_standard_claims (oidc_provider.tests.test_claims.ClaimsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/path/to/django-oidc-provider/oidc_provider/tests/test_claims.py", line 18, in test_empty_standard_claims
    self.assertEqual(v, '')
AssertionError: 'Doe' != ''
```
