### PR TITLE
Log create_uri_response exceptions to logger.exception

### DIFF
--- a/oidc_provider/lib/endpoints/authorize.py
+++ b/oidc_provider/lib/endpoints/authorize.py
@@ -207,7 +207,7 @@ class AuthorizeEndpoint(object):
                     query_fragment['session_state'] = session_state
 
         except Exception as error:
-            logger.debug('[Authorize] Error when trying to create response uri: %s', error)
+            logger.exception('[Authorize] Error when trying to create response uri: %s', error)
             raise AuthorizeError(self.params['redirect_uri'], 'server_error', self.grant_type)
 
         uri = uri._replace(query=urlencode(query_params, doseq=True))


### PR DESCRIPTION
We had quite some troubling trying to figure out what went wrong on our production servers, because as it turns out `create_uri_response` swallows all exceptions and writes it to `logger.debug`. This is quite a hassle when trying to find out what is going wrong on production servers. Therefore I propose the switch the `logger.exception` (so the actual exception is posted as well). This way people trying to debug their production servers have a bigger chance to find what went wrong. This is also useful for logging exceptions/errors to external exception monitoring such as Opbeat or Sentry.

Let me know what you guys think and if I should make any improvements.