### PR TITLE
Accept access_token as id_token_hint, not only JWT

### DIFF
--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -37,7 +37,7 @@ from oidc_provider.lib.utils.common import (
 from oidc_provider.lib.utils.oauth2 import protected_resource_view
 from oidc_provider.lib.utils.token import client_id_from_id_token
 from oidc_provider.models import (
-    Client,
+    Client, Token,
     RESPONSE_TYPE_CHOICES,
     RSAKey,
 )
@@ -263,9 +263,22 @@ class EndSessionView(View):
         next_page = settings.get('LOGIN_URL')
 
         if id_token_hint:
-            client_id = client_id_from_id_token(id_token_hint)
-            try:
-                client = Client.objects.get(client_id=client_id)
+            client = None
+            if '.' in id_token_hint:
+                # looks like JWT
+                try:
+                    client = Client.objects.get(
+                        client_id=client_id_from_id_token(id_token_hint)
+                    )
+                except Client.DoesNotExist:
+                    pass
+            else:
+                # in hope it's access_token
+                try:
+                    client = Token.objects.select_related('client').get(access_token=id_token_hint).client
+                except Token.DoesNotExist:
+                    pass
+            if client is not None:
                 if post_logout_redirect_uri in client.post_logout_redirect_uris:
                     if state:
                         uri = urlsplit(post_logout_redirect_uri)
@@ -275,8 +288,6 @@ class EndSessionView(View):
                         next_page = urlunsplit(uri)
                     else:
                         next_page = post_logout_redirect_uri
-            except Client.DoesNotExist:
-                pass
 
         return logout(request, next_page=next_page)
 


### PR DESCRIPTION
some client software sends just auth_token, not JWT, in this field. And this is just hint, and I haven't found any specific JWT mention in OIDC specification here.

And old code raised an exception in case of anything non-JWT in this field, and any way ignored the true redirect url.

So, now it works a little more... generic.