### PR TITLE
skipping consent only works for confidential clients

### DIFF
--- a/docs/sections/settings.rst
+++ b/docs/sections/settings.rst
@@ -101,7 +101,7 @@ Default is ``False``.
 OIDC_SKIP_CONSENT_ALWAYS
 ========================
 
-OPTIONAL. ``bool``. If enabled, the Server will NEVER ask the user for consent.
+OPTIONAL. ``bool``. If enabled, the Server will NEVER ask the user for consent if the client is confidential.
 
 Default is ``False``.
 


### PR DESCRIPTION
clarification that skipping consent only works for confidential clients