### PR TITLE
 Replaces `LOGIN_URL` with `OIDC_LOGIN_URL`

### DIFF
--- a/docs/sections/settings.rst
+++ b/docs/sections/settings.rst
@@ -5,12 +5,12 @@ Settings
 
 Customize your provider so fit your project needs.
 
-LOGIN_URL
+OIDC_LOGIN_URL
 =========
 
-REQUIRED. ``str``. Used to log the user in. `Read more in Django docs <https://docs.djangoproject.com/en/1.7/ref/settings/#login-url>`_
+OPTIONAL. ``str``. Used to log the user in. By default Django's ``LOGIN_URL`` will be used. `Read more in Django docs <https://docs.djangoproject.com/en/1.7/ref/settings/#login-url>`_
 
-``str``. Default is ``/accounts/login/``.
+``str``. Default is ``/accounts/login/`` (Django's ``LOGIN_URL``).
 
 SITE_URL
 ========

--- a/docs/sections/settings.rst
+++ b/docs/sections/settings.rst
@@ -6,7 +6,7 @@ Settings
 Customize your provider so fit your project needs.
 
 OIDC_LOGIN_URL
-=========
+==============
 
 OPTIONAL. ``str``. Used to log the user in. By default Django's ``LOGIN_URL`` will be used. `Read more in Django docs <https://docs.djangoproject.com/en/1.7/ref/settings/#login-url>`_
 

--- a/oidc_provider/settings.py
+++ b/oidc_provider/settings.py
@@ -4,16 +4,14 @@ from django.conf import settings
 
 
 class DefaultSettings(object):
-    required_attrs = (
-        'LOGIN_URL',
-    )
+    required_attrs = ()
 
     @property
-    def LOGIN_URL(self):
+    def OIDC_LOGIN_URL(self):
         """
-        REQUIRED. Used to log the user in.
+        REQUIRED. Used to log the user in. By default Django's LOGIN_URL will be used.
         """
-        return None
+        return settings.LOGIN_URL
 
     @property
     def SITE_URL(self):

--- a/oidc_provider/tests/test_authorize_endpoint.py
+++ b/oidc_provider/tests/test_authorize_endpoint.py
@@ -122,7 +122,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
         response = self._auth_request('get', data)
 
         # Check if user was redirected to the login view.
-        self.assertIn(settings.get('LOGIN_URL'), response['Location'])
+        self.assertIn(settings.get('OIDC_LOGIN_URL'), response['Location'])
 
     def test_user_consent_inputs(self):
         """

--- a/oidc_provider/tests/test_end_session_endpoint.py
+++ b/oidc_provider/tests/test_end_session_endpoint.py
@@ -36,7 +36,7 @@ class EndSessionTestCase(TestCase):
         }
         response = self.client.get(self.url, query_params)
         # With no id_token the OP MUST NOT redirect to the requested redirect_uri.
-        self.assertRedirects(response, settings.get('LOGIN_URL'), fetch_redirect_response=False)
+        self.assertRedirects(response, settings.get('OIDC_LOGIN_URL'), fetch_redirect_response=False)
 
         id_token_dic = create_id_token(user=self.user, aud=self.oidc_client.client_id)
         id_token = encode_id_token(id_token_dic, self.oidc_client)

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -79,7 +79,7 @@ class AuthorizeView(View):
                     raise AuthorizeError(authorize.params['redirect_uri'], 'interaction_required', authorize.grant_type)
 
                 if authorize.params['prompt'] == 'login':
-                    return redirect_to_login(request.get_full_path())
+                    return redirect_to_login(request.get_full_path(), settings.get('OIDC_LOGIN_URL'))
 
                 if authorize.params['prompt'] == 'select_account':
                     # TODO: see how we can support multiple accounts for the end-user.
@@ -108,7 +108,7 @@ class AuthorizeView(View):
                 if authorize.params['prompt'] == 'none':
                     raise AuthorizeError(authorize.params['redirect_uri'], 'login_required', authorize.grant_type)
 
-                return redirect_to_login(request.get_full_path())
+                return redirect_to_login(request.get_full_path(), settings.get('OIDC_LOGIN_URL'))
 
         except (ClientIdError, RedirectUriError) as error:
             context = {
@@ -268,7 +268,7 @@ class EndSessionView(View):
         state = request.GET.get('state', '')
         client = None
 
-        next_page = settings.get('LOGIN_URL')
+        next_page = settings.get('OIDC_LOGIN_URL')
         after_end_session_hook = settings.get('OIDC_AFTER_END_SESSION_HOOK', import_str=True)
 
         if id_token_hint:


### PR DESCRIPTION
This change allows users to use a different login path for their oidc requests.

`LOGIN_URL` is removed from the settings, but its value will be used by `redirect_to_login` as fallback if `OIDC_LOGIN_URL` is empty.