### PR TITLE
Fix documentation typo for OIDC_EXTRA_SCOPE_CLAIMS

### DIFF
--- a/docs/sections/scopesclaims.rst
+++ b/docs/sections/scopesclaims.rst
@@ -78,7 +78,7 @@ Let's say that you want add your custom ``foo`` scope for your OAuth2/OpenID pro
 
 Somewhere in your Django ``settings.py``::
 
-    OIDC_USERINFO = 'yourproject.oidc_provider_settings.CustomScopeClaims'
+    OIDC_EXTRA_SCOPE_CLAIMS = 'yourproject.oidc_provider_settings.CustomScopeClaims'
 
 Inside your oidc_provider_settings.py file add the following class::
 


### PR DESCRIPTION
Replace 'OIDC_USERINFO' with 'OIDC_EXTRA_SCOPE_CLAIMS' for extra scope claims settings.py