### PR TITLE
Don't pin exact versions in install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ setup(
     ],
     test_suite='runtests.runtests',
     tests_require=[
-        'pyjwkest==1.3.0',
-        'mock==2.0.0',
+        'pyjwkest>=1.3.0',
+        'mock>=2.0.0',
     ],
 
     install_requires=[
-        'pyjwkest==1.3.0',
+        'pyjwkest>=1.3.0',
     ],
 )


### PR DESCRIPTION
According to this: https://packaging.python.org/requirements/#install-requires-vs-requirements-files , dependencies should not be pinned to exact versions.