### PR TITLE
Fix Django 2.0 deprecation warnings

### DIFF
--- a/oidc_provider/lib/utils/common.py
+++ b/oidc_provider/lib/utils/common.py
@@ -1,4 +1,10 @@
-from django.core.urlresolvers import reverse
+import django
+
+if django.VERSION >= (1, 11):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
+
 from django.http import HttpResponse
 
 from oidc_provider import settings

--- a/oidc_provider/migrations/0001_initial.py
+++ b/oidc_provider/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                 ('expires_at', models.DateTimeField()),
                 ('_scope', models.TextField(default=b'')),
                 ('code', models.CharField(unique=True, max_length=255)),
-                ('client', models.ForeignKey(to='oidc_provider.Client')),
+                ('client', models.ForeignKey(to='oidc_provider.Client', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -49,7 +49,7 @@ class Migration(migrations.Migration):
                 ('_scope', models.TextField(default=b'')),
                 ('access_token', models.CharField(unique=True, max_length=255)),
                 ('_id_token', models.TextField()),
-                ('client', models.ForeignKey(to='oidc_provider.Client')),
+                ('client', models.ForeignKey(to='oidc_provider.Client', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='UserInfo',
             fields=[
-                ('user', models.OneToOneField(primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
                 ('given_name', models.CharField(max_length=255, null=True, blank=True)),
                 ('family_name', models.CharField(max_length=255, null=True, blank=True)),
                 ('middle_name', models.CharField(max_length=255, null=True, blank=True)),
@@ -89,13 +89,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='token',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='code',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/oidc_provider/migrations/0002_userconsent.py
+++ b/oidc_provider/migrations/0002_userconsent.py
@@ -19,8 +19,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('expires_at', models.DateTimeField()),
                 ('_scope', models.TextField(default=b'')),
-                ('client', models.ForeignKey(to='oidc_provider.Client')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('client', models.ForeignKey(to='oidc_provider.Client', on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -83,8 +83,8 @@ class Client(models.Model):
 
 class BaseCodeTokenModel(models.Model):
 
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_(u'User'))
-    client = models.ForeignKey(Client, verbose_name=_(u'Client'))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_(u'User'), on_delete=models.CASCADE)
+    client = models.ForeignKey(Client, verbose_name=_(u'Client'), on_delete=models.CASCADE)
     expires_at = models.DateTimeField(verbose_name=_(u'Expiration Date'))
     _scope = models.TextField(default='', verbose_name=_(u'Scopes'))
 

--- a/oidc_provider/urls.py
+++ b/oidc_provider/urls.py
@@ -6,7 +6,7 @@ from oidc_provider import (
     views,
 )
 
-
+app_name = 'oidc_provider'
 urlpatterns = [
     url(r'^authorize/?$', views.AuthorizeView.as_view(), name='authorize'),
     url(r'^token/?$', csrf_exempt(views.TokenView.as_view()), name='token'),

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -10,7 +10,12 @@ from django.contrib.auth.views import (
     redirect_to_login,
     logout,
 )
-from django.core.urlresolvers import reverse
+
+import django
+if django.VERSION >= (1, 11):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.template.loader import render_to_string


### PR DESCRIPTION
This fixes a number of Django 2.0 deprecation warnings that were introduced in Django 1.11. These are needed for anyone who is planning on upgrading to Django 1.11 and whose code base raises any warnings to the error level.

These changes should be fully backwards compatible.

Warnings fixed:
- `on_delete` will be mandatory in any `ForeignKey(...)` definitions (even in migrations)
- `django.core.urlresolvers.reverse` is moving to `django.urls.reverse`
- `app_name` required in `urls.py` for each app.