### PR TITLE
Fixed client id retrieval when aud is a list of str.

### DIFF
--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -91,7 +91,12 @@ def client_id_from_id_token(id_token):
     Returns a string or None.
     """
     payload = JWT().unpack(id_token).payload()
-    return payload.get('aud', None)
+    aud = payload.get('aud', None)
+    if aud is None:
+        return None
+    if isinstance(aud, list):
+        return aud[0]
+    return aud
 
 
 def create_token(user, client, scope, id_token_dic=None):

--- a/oidc_provider/tests/test_end_session_endpoint.py
+++ b/oidc_provider/tests/test_end_session_endpoint.py
@@ -30,30 +30,40 @@ class EndSessionTestCase(TestCase):
 
         self.url = reverse('oidc_provider:end-session')
 
-    def test_redirects(self):
+    def test_redirects_when_aud_is_str(self):
         query_params = {
             'post_logout_redirect_uri': self.LOGOUT_URL,
         }
         response = self.client.get(self.url, query_params)
-        # With no id_token the OP MUST NOT redirect to the requested redirect_uri.
-        self.assertRedirects(response, settings.get('OIDC_LOGIN_URL'), fetch_redirect_response=False)
+        # With no id_token the OP MUST NOT redirect to the requested
+        # redirect_uri.
+        self.assertRedirects(
+            response, settings.get('OIDC_LOGIN_URL'),
+            fetch_redirect_response=False)
 
-        id_token_dic = create_id_token(user=self.user, aud=self.oidc_client.client_id)
+        id_token_dic = create_id_token(
+            user=self.user, aud=self.oidc_client.client_id)
         id_token = encode_id_token(id_token_dic, self.oidc_client)
 
         query_params['id_token_hint'] = id_token
 
         response = self.client.get(self.url, query_params)
-        self.assertRedirects(response, self.LOGOUT_URL, fetch_redirect_response=False)
+        self.assertRedirects(
+            response, self.LOGOUT_URL, fetch_redirect_response=False)
 
-        # Check with 'aud' containing a list of str
+    def test_redirects_when_aud_is_list(self):
+        """Check with 'aud' containing a list of str."""
+        query_params = {
+            'post_logout_redirect_uri': self.LOGOUT_URL,
+        }
+        id_token_dic = create_id_token(
+            user=self.user, aud=self.oidc_client.client_id)
         id_token_dic['aud'] = [id_token_dic['aud']]
         id_token = encode_id_token(id_token_dic, self.oidc_client)
         query_params['id_token_hint'] = id_token
         response = self.client.get(self.url, query_params)
         self.assertRedirects(
             response, self.LOGOUT_URL, fetch_redirect_response=False)
-
 
     @mock.patch(settings.get('OIDC_AFTER_END_SESSION_HOOK'))
     def test_call_post_end_session_hook(self, hook_function):

--- a/oidc_provider/tests/test_end_session_endpoint.py
+++ b/oidc_provider/tests/test_end_session_endpoint.py
@@ -46,6 +46,15 @@ class EndSessionTestCase(TestCase):
         response = self.client.get(self.url, query_params)
         self.assertRedirects(response, self.LOGOUT_URL, fetch_redirect_response=False)
 
+        # Check with 'aud' containing a list of str
+        id_token_dic['aud'] = [id_token_dic['aud']]
+        id_token = encode_id_token(id_token_dic, self.oidc_client)
+        query_params['id_token_hint'] = id_token
+        response = self.client.get(self.url, query_params)
+        self.assertRedirects(
+            response, self.LOGOUT_URL, fetch_redirect_response=False)
+
+
     @mock.patch(settings.get('OIDC_AFTER_END_SESSION_HOOK'))
     def test_call_post_end_session_hook(self, hook_function):
         self.client.get(self.url)


### PR DESCRIPTION
According to https://openid.net/specs/openid-connect-core-1_0.html#IDToken:

> aud
REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain identifiers for other audiences. In the general case, the aud value is an array of case sensitive strings. In the common special case when there is one audience, the aud value MAY be a single case sensitive string.

I can confirm this behaviour when using https://github.com/OpenIDC/pyoidc as client which always send ``aud`` within a list.

This PR solves my use case but does not solve the case where multiple token ids are provided.