### PR TITLE
Use request.user.is_authenticated as a bool with recent Django

### DIFF
--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -65,7 +65,7 @@ class AuthorizeView(View):
         try:
             authorize.validate_params()
 
-            if request.user.is_authenticated():
+            if (request.user.is_authenticated if django.VERSION >= (1, 10) else request.user.is_authenticated()):
                 # Check if there's a hook setted.
                 hook_resp = settings.get('OIDC_AFTER_USERLOGIN_HOOK', import_str=True)(
                     request=request, user=request.user,


### PR DESCRIPTION
Django 1.10 changed ``request.user.is_authenticated`` from a function to a boolean and Django 2.0 dropped the backward compatibility. In order to use django-oidc-provider with Django 2.0, ``AuthorizeView`` needs to handle ``request.user.is_authenticated`` as a boolean.