### PR TITLE
[OCS-243] Update project to support Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,11 @@ env:
   - DJANGO=1.9
   - DJANGO=1.10
   - DJANGO=1.11
+  - DJANGO=2.0
 matrix:
   exclude:
+    - python: "2.7"
+      env: DJANGO=2.0
     - python: "3.5"
       env: DJANGO=1.7
     - python: "3.6"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-### [Unreleased]
+### [0.5.3] - 2018-02-01
 
+##### Fixed
+- Update project to support Django 2.0
 
 ### [0.5.2] - 2017-08-22
 
 ##### Fixed
 -	Fix infinite login loop if "prompt=login" (#198)
 - Fix Django 2.0 deprecation warnings (#185) 
-
 
 ### [0.5.1] - 2017-07-11
 

--- a/example_project/myapp/settings.py
+++ b/example_project/myapp/settings.py
@@ -29,11 +29,11 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'oidc_provider.middleware.SessionManagementMiddleware',
 ]
+MIDDLEWARE = MIDDLEWARE_CLASSES
 
 TEMPLATES = [
     {

--- a/example_project/myapp/urls.py
+++ b/example_project/myapp/urls.py
@@ -1,15 +1,16 @@
 from django.contrib.auth import views as auth_views
-from django.conf.urls import include, url
+try:
+    from django.urls import include, url
+except ImportError:
+    from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import TemplateView
 
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='home.html'), name='home'),
-    url(r'^accounts/login/$', auth_views.login, { 'template_name': 'login.html' }, name='login'),
-    url(r'^accounts/logout/$', auth_views.logout, { 'next_page': '/' }, name='logout'),
-
+    url(r'^accounts/login/$', auth_views.login, {'template_name': 'login.html'}, name='login'),
+    url(r'^accounts/logout/$', auth_views.logout, {'next_page': '/'}, name='logout'),
     url(r'^', include('oidc_provider.urls', namespace='oidc_provider')),
-
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/oidc_provider/compat.py
+++ b/oidc_provider/compat.py
@@ -1,0 +1,5 @@
+def get_attr_or_callable(obj, name):
+    target = getattr(obj, name)
+    if callable(target):
+        return target()
+    return target

--- a/oidc_provider/tests/app/urls.py
+++ b/oidc_provider/tests/app/urls.py
@@ -1,5 +1,8 @@
 from django.contrib.auth import views as auth_views
-from django.conf.urls import include, url
+try:
+    from django.urls import include, url
+except ImportError:
+    from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import TemplateView
 
@@ -11,5 +14,5 @@ urlpatterns = [
 
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
 
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/oidc_provider/tests/test_authorize_endpoint.py
+++ b/oidc_provider/tests/test_authorize_endpoint.py
@@ -13,7 +13,10 @@ from mock import patch, mock
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test import (
     RequestFactory,
     override_settings,

--- a/oidc_provider/tests/test_end_session_endpoint.py
+++ b/oidc_provider/tests/test_end_session_endpoint.py
@@ -1,5 +1,8 @@
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test import TestCase
 
 from oidc_provider.lib.utils.token import (
@@ -51,4 +54,3 @@ class EndSessionTestCase(TestCase):
         self.client.get(self.url)
         self.assertTrue(hook_function.called, 'OIDC_AFTER_END_SESSION_HOOK should be called')
         self.assertTrue(hook_function.call_count == 1, 'OIDC_AFTER_END_SESSION_HOOK should be called once but was {}'.format(hook_function.call_count))
-

--- a/oidc_provider/tests/test_middleware.py
+++ b/oidc_provider/tests/test_middleware.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+try:
+    from django.urls import url
+except ImportError:
+    from django.conf.urls import url
 from django.test import TestCase, override_settings
 from django.views.generic import View
 from mock import mock

--- a/oidc_provider/tests/test_provider_info_endpoint.py
+++ b/oidc_provider/tests/test_provider_info_endpoint.py
@@ -1,4 +1,7 @@
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test import RequestFactory
 from django.test import TestCase
 

--- a/oidc_provider/tests/test_token_endpoint.py
+++ b/oidc_provider/tests/test_token_endpoint.py
@@ -9,7 +9,10 @@ except ImportError:
     from urllib import urlencode
 
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test import (
     RequestFactory,
     override_settings,

--- a/oidc_provider/tests/test_userinfo_endpoint.py
+++ b/oidc_provider/tests/test_userinfo_endpoint.py
@@ -6,7 +6,10 @@ try:
 except ImportError:
     from urllib import urlencode
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test import RequestFactory
 from django.test import TestCase
 from django.utils import timezone

--- a/oidc_provider/urls.py
+++ b/oidc_provider/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+try:
+    from django.urls import url
+except ImportError:
+    from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from oidc_provider import (

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -11,13 +11,10 @@ from django.contrib.auth.views import (
     redirect_to_login,
     logout,
 )
-
-import django
-if django.VERSION >= (1, 11):
+try:
     from django.urls import reverse
-else:
+except ImportError:
     from django.core.urlresolvers import reverse
-
 from django.contrib.auth import logout as django_user_logout
 from django.http import JsonResponse
 from django.shortcuts import render
@@ -28,6 +25,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.generic import View
 from jwkest import long_to_base64
 
+from oidc_provider.compat import get_attr_or_callable
 from oidc_provider.lib.claims import StandardScopeClaims
 from oidc_provider.lib.endpoints.authorize import AuthorizeEndpoint
 from oidc_provider.lib.endpoints.token import TokenEndpoint
@@ -65,7 +63,7 @@ class AuthorizeView(View):
         try:
             authorize.validate_params()
 
-            if request.user.is_authenticated():
+            if get_attr_or_callable(request.user, 'is_authenticated'):
                 # Check if there's a hook setted.
                 hook_resp = settings.get('OIDC_AFTER_USERLOGIN_HOOK', import_str=True)(
                     request=request, user=request.user,

--- a/runtests.py
+++ b/runtests.py
@@ -9,24 +9,30 @@ from django.conf import settings
 
 DEFAULT_SETTINGS = dict(
 
-    DEBUG = False,
+    DEBUG=False,
 
-    DATABASES = {
+    DATABASES={
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': ':memory:',
         }
     },
 
-    SITE_ID = 1,
+    SITE_ID=1,
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE_CLASSES=[
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
     ],
 
-    TEMPLATES = [
+    MIDDLEWARE=[
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+    ],
+
+    TEMPLATES=[
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'DIRS': [],
@@ -42,7 +48,7 @@ DEFAULT_SETTINGS = dict(
         },
     ],
 
-    LOGGING = {
+    LOGGING={
         'version': 1,
         'disable_existing_loggers': False,
         'handlers': {
@@ -58,7 +64,7 @@ DEFAULT_SETTINGS = dict(
         },
     },
 
-    INSTALLED_APPS = [
+    INSTALLED_APPS=[
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',
@@ -68,20 +74,20 @@ DEFAULT_SETTINGS = dict(
         'oidc_provider',
     ],
 
-    SECRET_KEY = 'this-should-be-top-secret',
+    SECRET_KEY='this-should-be-top-secret',
 
-    ROOT_URLCONF = 'oidc_provider.tests.app.urls',
+    ROOT_URLCONF='oidc_provider.tests.app.urls',
 
-    TEMPLATE_DIRS = [
+    TEMPLATE_DIRS=[
         'oidc_provider/tests/templates',
     ],
 
-    USE_TZ = True,
+    USE_TZ=True,
 
     # OIDC Provider settings.
 
-    SITE_URL = 'http://localhost:8000',
-    OIDC_USERINFO = 'oidc_provider.tests.app.utils.userinfo',
+    SITE_URL='http://localhost:8000',
+    OIDC_USERINFO='oidc_provider.tests.app.utils.userinfo',
 
 )
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-oidc-provider',
-    version='0.5.2',
+    version='0.5.3',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@
 envlist=
     clean,
     py27-django{17,18,19,110,111},
-    py34-django{17,18,19,110,111},
-    py35-django{18,19,110,111},
-    py36-django{18,19,110,111},
+    py34-django{17,18,19,110,111,20},
+    py35-django{18,19,110,111,20},
+    py36-django{18,19,110,111,20},
 
 [testenv]
 
@@ -15,6 +15,7 @@ deps =
     django19: django>=1.9,<1.10
     django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
+    django20: django>=2.0,<2.1
     coverage
     mock
 


### PR DESCRIPTION
Task: https://jira-olist.atlassian.net/browse/OCS-216
Subtask: https://jira-olist.atlassian.net/browse/OCS-243

Atualiza o projeto para funcionar com Django 2.0, após o merge a versão olist-django-oidc-provider será lançada, isso é necessário para atualizar a sellers-api para o Django 2.0: https://jira-olist.atlassian.net/browse/OCS-223.

Testado com o tox:
```
_________________________________________________________________________________ summary __________________________________________________________________________________
  clean: commands succeeded
  py27-django17: commands succeeded
  py27-django18: commands succeeded
  py27-django19: commands succeeded
  py27-django110: commands succeeded
  py27-django111: commands succeeded
  py34-django17: commands succeeded
  py34-django18: commands succeeded
  py34-django19: commands succeeded
  py34-django110: commands succeeded
  py34-django111: commands succeeded
  py34-django20: commands succeeded
  py35-django18: commands succeeded
  py35-django19: commands succeeded
  py35-django110: commands succeeded
  py35-django111: commands succeeded
  py35-django20: commands succeeded
  py36-django18: commands succeeded
  py36-django19: commands succeeded
  py36-django110: commands succeeded
  py36-django111: commands succeeded
  py36-django20: commands succeeded
  congratulations :)
```