### PR TITLE
Fixed infinite callback loop in the check-session iframe

### DIFF
--- a/oidc_provider/templates/oidc_provider/check_session_iframe.html
+++ b/oidc_provider/templates/oidc_provider/check_session_iframe.html
@@ -9,6 +9,10 @@
             window.addEventListener("message", receiveMessage, false);
 
             function receiveMessage(e) {
+                if (!e.data || typeof e.data != 'string' || e.data == 'error') {
+                    return;
+                }
+
                 var status;
                 try {
                     var clientId = e.data.split(' ')[0];


### PR DESCRIPTION
This commit fixes the JS callback defined in the check-session iframe which can produce infinite callback loops if the received message doesn't come from the relying party. In that case another message (whose data corresponds to `error`) is posted to the source of the message (which can be the OP itself) thus resulting in an infinite loop because `error` messages are continuously generated by the callback function.