### PR TITLE
Remove scope param from OIDC_IDTOKEN_PROCESSING_HOOK

### DIFF
--- a/docs/sections/changelog.rst
+++ b/docs/sections/changelog.rst
@@ -11,7 +11,7 @@ Unreleased
 * Added: token instrospection endpoint support (RFC7662).
 * Added: request in password grant authenticate call.
 * Changed: dropping support for Django versions before 1.8.
-* Changed: pass scope, token and request to OIDC_IDTOKEN_PROCESSING_HOOK.
+* Changed: pass token and request to OIDC_IDTOKEN_PROCESSING_HOOK.
 
 0.6.0
 =====

--- a/docs/sections/settings.rst
+++ b/docs/sections/settings.rst
@@ -96,7 +96,6 @@ The hook function receives following arguments:
    processing hooks are configured, then the claims of the previous hook
    are also present in the passed dictionary.
  * ``user``: User object of the authenticating user,
- * ``scope``: the authorized scopes as list of strings or None,
  * ``token``: the Token object created for the authentication request, and
  * ``request``: Django request object of the authentication request.
 
@@ -109,7 +108,7 @@ The hook function should return the modified ID token as dictionary.
 
 Default is::
 
-    def default_idtoken_processing_hook(id_token, user, scope, token, request, **kwargs):
+    def default_idtoken_processing_hook(id_token, user, token, request, **kwargs):
 
         return id_token
 

--- a/oidc_provider/lib/utils/common.py
+++ b/oidc_provider/lib/utils/common.py
@@ -108,7 +108,7 @@ def default_after_end_session_hook(
 
 
 def default_idtoken_processing_hook(
-        id_token, user, scope, token, request, **kwargs):
+        id_token, user, token, request, **kwargs):
     """
     Hook for modifying `id_token` just before serialization.
 
@@ -117,9 +117,6 @@ def default_idtoken_processing_hook(
 
     :param user: user for whom id_token is generated
     :type user: User
-
-    :param scope: scope for the token
-    :type scope: list[str]|None
 
     :param token: the Token object created for the authentication request
     :type token: oidc_provider.models.Token

--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -64,7 +64,7 @@ def create_id_token(token, user, aud, nonce='', at_hash='', request=None, scope=
 
     dic = run_processing_hook(
         dic, 'OIDC_IDTOKEN_PROCESSING_HOOK',
-        user=user, scope=scope, token=token, request=request)
+        user=user, token=token, request=request)
 
     return dic
 

--- a/oidc_provider/tests/app/utils.py
+++ b/oidc_provider/tests/app/utils.py
@@ -132,11 +132,11 @@ def fake_idtoken_processing_hook2(id_token, user, **kwargs):
     return id_token
 
 
-def fake_idtoken_processing_hook3(id_token, user, scope=None, **kwargs):
+def fake_idtoken_processing_hook3(id_token, user, token, **kwargs):
     """
     Fake function for checking scope is passed to processing hook.
     """
-    id_token['scope_passed_to_processing_hook'] = scope
+    id_token['scope_of_token_passed_to_processing_hook'] = token.scope
     return id_token
 
 

--- a/oidc_provider/tests/cases/test_token_endpoint.py
+++ b/oidc_provider/tests/cases/test_token_endpoint.py
@@ -731,14 +731,14 @@ class TokenTestCase(TestCase):
     @override_settings(
         OIDC_IDTOKEN_PROCESSING_HOOK=(
                 'oidc_provider.tests.app.utils.fake_idtoken_processing_hook3'))
-    def test_additional_idtoken_processing_hook_scope_param(self):
+    def test_additional_idtoken_processing_hook_scope_available(self):
         """
-        Test scope parameter is passed to OIDC_IDTOKEN_PROCESSING_HOOK.
+        Test scope is available in OIDC_IDTOKEN_PROCESSING_HOOK.
         """
         id_token = self._request_id_token_with_scope(
             ['openid', 'email', 'profile', 'dummy'])
         self.assertEqual(
-            id_token.get('scope_passed_to_processing_hook'),
+            id_token.get('scope_of_token_passed_to_processing_hook'),
             ['openid', 'email', 'profile', 'dummy'])
 
     @override_settings(
@@ -751,12 +751,11 @@ class TokenTestCase(TestCase):
         id_token = self._request_id_token_with_scope(['openid', 'profile'])
         kwargs_passed = id_token.get('kwargs_passed_to_processing_hook')
         assert kwargs_passed
-        self.assertEqual(kwargs_passed.get('scope'),
-                         repr([u'openid', u'profile']))
         self.assertEqual(kwargs_passed.get('token'),
                          '<Token: Some Client - johndoe@example.com>')
         self.assertEqual(kwargs_passed.get('request'),
                          "<WSGIRequest: POST '/openid/token'>")
+        self.assertEqual(set(kwargs_passed.keys()), {'token', 'request'})
 
     def _request_id_token_with_scope(self, scope):
         code = self._create_code(scope)


### PR DESCRIPTION
There is no need to pass in the scope parameter separately, since the
scope is available via the token parameter already.