### PR TITLE
Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ matrix:
           - ENV=docs
     - python: 2.7
       env:
-          - ENV=py27-django18,py27-django19,py27-django110,py27-django111
+          - ENV=py27-django111
     - python: 3.4
       env:
-          - ENV=py34-django18,py34-django19,py34-django110,py34-django111,py34-django20
+          - ENV=py34-django111,py34-django20,py34-django21
     - python: 3.5
       env:
-          - ENV=py35-django18,py35-django19,py35-django110,py35-django111,py35-django20
+          - ENV=py35-django111,py35-django20,py35-django21
     - python: 3.6
       env:
-          - ENV=py36-django18,py36-django19,py36-django110,py36-django111,py36-django20
+          - ENV=py36-django111,py36-django20,py36-django21
 script:
   - tox -e $ENV
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
     - python: 2.7
       env:
           - ENV=py27-django111
-    - python: 3.4
-      env:
-          - ENV=py34-django111,py34-django20,py34-django21
     - python: 3.5
       env:
           - ENV=py35-django111,py35-django20,py35-django21

--- a/oidc_provider/tests/app/urls.py
+++ b/oidc_provider/tests/app/urls.py
@@ -10,9 +10,9 @@ from django.views.generic import TemplateView
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='home.html'), name='home'),
     url(r'^accounts/login/$',
-        auth_views.login, {'template_name': 'accounts/login.html'}, name='login'),
+        auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
     url(r'^accounts/logout/$',
-        auth_views.logout, {'template_name': 'accounts/logout.html'}, name='logout'),
+        auth_views.LogoutView.as_view(template_name='accounts/logout.html'), name='logout'),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^admin/', admin.site.urls),
 ]

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -12,7 +12,7 @@ except ImportError:
 from Cryptodome.PublicKey import RSA
 from django.contrib.auth.views import (
     redirect_to_login,
-    logout,
+    LogoutView,
 )
 try:
     from django.urls import reverse
@@ -326,8 +326,8 @@ class JwksView(View):
         return response
 
 
-class EndSessionView(View):
-    def get(self, request, *args, **kwargs):
+class EndSessionView(LogoutView):
+    def dispatch(self, request, *args, **kwargs):
         id_token_hint = request.GET.get('id_token_hint', '')
         post_logout_redirect_uri = request.GET.get('post_logout_redirect_uri', '')
         state = request.GET.get('state', '')
@@ -361,7 +361,8 @@ class EndSessionView(View):
             next_page=next_page
         )
 
-        return logout(request, next_page=next_page)
+        self.next_page = next_page
+        return super(EndSessionView, self).dispatch(request, *args, **kwargs)
 
 
 class CheckSessionIframeView(View):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist=
     docs,
     py27-django{111},
-    py34-django{111,20,21},
     py35-django{111,20,21},
     py36-django{111,20,21},
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist=
     docs,
-    py27-django{18,19,110,111},
-    py34-django{18,19,110,111,20},
-    py35-django{18,19,110,111,20},
-    py36-django{18,19,110,111,20},
+    py27-django{111},
+    py34-django{111,20,21},
+    py35-django{111,20,21},
+    py36-django{111,20,21},
 
 [testenv]
 changedir=
@@ -16,11 +16,9 @@ deps =
     pytest-django
     pytest-flake8
     pytest-cov
-    django18: django>=1.8,<1.9
-    django19: django>=1.9,<1.10
-    django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
     django20: django>=2.0,<2.1
+    django21: django>=2.1,<2.2
 
 commands =
     pytest --flake8 --cov=oidc_provider {posargs}


### PR DESCRIPTION
Django 1.11 deprecated the django.contrib.auth.views.logout
function-based view, which django-oidc-provider relied on. This
patchset instead subclasses the new LogoutView.

LogoutView was introduced in Django 1.11. logout() was deprecated in
1.11 and removed in 2.1. Accordingly, this patch adds Django 2.1 to
CI and removes 1.8, 1.9, and 1.10.

Resolves #258