### PR TITLE
Accept lowercase "bearer" in Authorization header

### DIFF
--- a/docs/sections/changelog.rst
+++ b/docs/sections/changelog.rst
@@ -9,6 +9,7 @@ Unreleased
 ==========
 
 * Added: support introspection on client credentials tokens.
+* Changed: accept lowercase "bearer" in Authorization header.
 * Fixed: ScopeClaims class.
 * Fixed: code is not zip safe.
 

--- a/oidc_provider/lib/utils/oauth2.py
+++ b/oidc_provider/lib/utils/oauth2.py
@@ -21,7 +21,7 @@ def extract_access_token(request):
     """
     auth_header = request.META.get('HTTP_AUTHORIZATION', '')
 
-    if re.compile('^Bearer\s{1}.+$').match(auth_header):
+    if re.compile('^[Bb]earer\s{1}.+$').match(auth_header):
         access_token = auth_header.split()[1]
     else:
         access_token = request.GET.get('access_token', '')

--- a/oidc_provider/tests/cases/test_userinfo_endpoint.py
+++ b/oidc_provider/tests/cases/test_userinfo_endpoint.py
@@ -59,7 +59,7 @@ class UserInfoTestCase(TestCase):
 
         return token
 
-    def _post_request(self, access_token):
+    def _post_request(self, access_token, schema='Bearer'):
         """
         Makes a request to the userinfo endpoint by sending the
         `post_data` parameters using the 'multipart/form-data'
@@ -69,7 +69,7 @@ class UserInfoTestCase(TestCase):
 
         request = self.factory.post(url, data={}, content_type='multipart/form-data')
 
-        request.META['HTTP_AUTHORIZATION'] = 'Bearer ' + access_token
+        request.META['HTTP_AUTHORIZATION'] = schema + ' ' + access_token
 
         response = userinfo(request)
 
@@ -80,6 +80,18 @@ class UserInfoTestCase(TestCase):
 
         # Test a valid request to the userinfo endpoint.
         response = self._post_request(token.access_token)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(bool(response.content), True)
+
+    def test_response_with_valid_token_lowercase_bearer(self):
+        """
+        Some clients expect to be able to pass the token_type value from the token endpoint
+        ("bearer") back to the identity provider unchanged.
+        """
+        token = self._create_token()
+
+        response = self._post_request(token.access_token, schema='bearer')
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(bool(response.content), True)


### PR DESCRIPTION
We ran into a client that blindly takes the value of token_type, which
is lowercase "bearer", and passes that back in the Authorization header.
In an earlier PR #99 there seemed to be some support for this change to
simply accept "bearer" in addition to "Bearer".