### PR TITLE
add natural key support to ResponseType

### DIFF
--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -30,7 +30,14 @@ JWT_ALGS = [
 ]
 
 
+class ResponseTypeManager(models.Manager):
+    def get_by_natural_key(self, value):
+        return self.get(value=value)
+
+
 class ResponseType(models.Model):
+    objects = ResponseTypeManager()
+
     value = models.CharField(
         max_length=30,
         choices=RESPONSE_TYPE_CHOICES,
@@ -39,6 +46,9 @@ class ResponseType(models.Model):
     description = models.CharField(
         max_length=50,
     )
+
+    def natural_key(self):
+        return self.value,  # natural_key must return tuple
 
     def __str__(self):
         return u'{0}'.format(self.description)


### PR DESCRIPTION
Have the option to use the more readable response type value rather than
the ResponseType id integer in fixtures and dumpdata output. Prior to my
multiple response type change the nice string value was all that was available.
This PR adds that back as an option.

Prior to this change dumpdata represents response types like so:

    "response_types": [2]

And after this change when using `dumpdata --natural-foreign`:

    "response_types": [["code"]]