### PR TITLE
Add missing space

### DIFF
--- a/oidc_provider/lib/claims.py
+++ b/oidc_provider/lib/claims.py
@@ -120,7 +120,7 @@ class StandardScopeClaims(ScopeClaims):
 
     info_profile = (
         _(u'Basic profile'),
-        _(u'Access to your basic information. Includes names, gender, birthdate'
+        _(u'Access to your basic information. Includes names, gender, birthdate '
           'and other information.'),
     )
 


### PR DESCRIPTION
When strings get concatenated it currently contains "birthdateand" typo due to missing space.