### PR TITLE
Make it easier to change AuthorizeEndpoint and Client

### DIFF
--- a/oidc_provider/lib/endpoints/authorize.py
+++ b/oidc_provider/lib/endpoints/authorize.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 class AuthorizeEndpoint(object):
     _allowed_prompt_params = {'none', 'login', 'consent', 'select_account'}
+    client_class = Client
 
     def __init__(self, request):
         self.request = request
@@ -86,7 +87,7 @@ class AuthorizeEndpoint(object):
     def validate_params(self):
         # Client validation.
         try:
-            self.client = Client.objects.get(client_id=self.params['client_id'])
+            self.client = self.client_class.objects.get(client_id=self.params['client_id'])
         except Client.DoesNotExist:
             logger.debug('[Authorize] Invalid client identifier: %s', self.params['client_id'])
             raise ClientIdError()

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -61,9 +61,10 @@ OIDC_TEMPLATES = settings.get('OIDC_TEMPLATES')
 
 
 class AuthorizeView(View):
-    def get(self, request, *args, **kwargs):
+    authorize_endpoint_class = AuthorizeEndpoint
 
-        authorize = AuthorizeEndpoint(request)
+    def get(self, request, *args, **kwargs):
+        authorize = self.authorize_endpoint_class(request)
 
         try:
             authorize.validate_params()


### PR DESCRIPTION
To make it easier to change the AuthorizeEndpoint and Client we set them as class variables. Then people inheriting from the view are able to easily change them. In my personal case this helps with skipping consent more explicitly as defined in issue https://github.com/juanifioren/django-oidc-provider/issues/278