### PR TITLE
Revert "Fixed #285 -- Ensured standard and custom claims can be used at the same time when using the OIDC_IDTOKEN_INCLUDE_CLAIMS setting"

### DIFF
--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -55,11 +55,12 @@ def create_id_token(token, user, aud, nonce='', at_hash='', request=None, scope=
 
     # Inlude (or not) user standard claims in the id_token.
     if settings.get('OIDC_IDTOKEN_INCLUDE_CLAIMS'):
-        standard_claims = StandardScopeClaims(token)
-        dic.update(standard_claims.create_response_dic())
         if settings.get('OIDC_EXTRA_SCOPE_CLAIMS'):
             custom_claims = settings.get('OIDC_EXTRA_SCOPE_CLAIMS', import_str=True)(token)
-            dic.update(custom_claims.create_response_dic())
+            claims = custom_claims.create_response_dic()
+        else:
+            claims = StandardScopeClaims(token).create_response_dic()
+        dic.update(claims)
 
     dic = run_processing_hook(
         dic, 'OIDC_IDTOKEN_PROCESSING_HOOK',


### PR DESCRIPTION
Reverts juanifioren/django-oidc-provider#286