### PR TITLE
Enhancement: AuthorizeView's static method strip-prompt-login moved

### DIFF
--- a/oidc_provider/lib/utils/authorize.py
+++ b/oidc_provider/lib/utils/authorize.py
@@ -1,0 +1,21 @@
+try:
+    from urllib import urlencode
+    from urlparse import urlsplit, parse_qs, urlunsplit
+except ImportError:
+    from urllib.parse import urlsplit, parse_qs, urlunsplit, urlencode
+
+
+def strip_prompt_login(path):
+    """
+    Strips 'login' from the 'prompt' query parameter.
+    """
+    uri = urlsplit(path)
+    query_params = parse_qs(uri.query)
+    prompt_list = query_params.get('prompt', '')[0].split()
+    if 'login' in prompt_list:
+        prompt_list.remove('login')
+        query_params['prompt'] = ' '.join(prompt_list)
+    if not query_params['prompt']:
+        del query_params['prompt']
+    uri = uri._replace(query=urlencode(query_params, doseq=True))
+    return urlunsplit(uri)

--- a/oidc_provider/tests/cases/test_authorize_endpoint.py
+++ b/oidc_provider/tests/cases/test_authorize_endpoint.py
@@ -31,6 +31,7 @@ from oidc_provider.tests.app.utils import (
     FAKE_CODE_CHALLENGE,
     is_code_valid,
 )
+from oidc_provider.lib.utils.authorize import strip_prompt_login
 from oidc_provider.views import AuthorizeView
 from oidc_provider.lib.endpoints.authorize import AuthorizeEndpoint
 
@@ -481,20 +482,20 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
                  '_id=112233&prompt=login none&redirect_uri' +
                  '=http://localhost:8000')
 
-        self.assertNotIn('prompt', AuthorizeView.strip_prompt_login(path0))
+        self.assertNotIn('prompt', strip_prompt_login(path0))
 
-        self.assertIn('prompt', AuthorizeView.strip_prompt_login(path1))
-        self.assertIn('consent', AuthorizeView.strip_prompt_login(path1))
-        self.assertIn('none', AuthorizeView.strip_prompt_login(path1))
-        self.assertNotIn('login', AuthorizeView.strip_prompt_login(path1))
+        self.assertIn('prompt', strip_prompt_login(path1))
+        self.assertIn('consent', strip_prompt_login(path1))
+        self.assertIn('none', strip_prompt_login(path1))
+        self.assertNotIn('login', strip_prompt_login(path1))
 
-        self.assertIn('prompt', AuthorizeView.strip_prompt_login(path2))
-        self.assertIn('consent', AuthorizeView.strip_prompt_login(path1))
-        self.assertNotIn('login', AuthorizeView.strip_prompt_login(path2))
+        self.assertIn('prompt', strip_prompt_login(path2))
+        self.assertIn('consent', strip_prompt_login(path1))
+        self.assertNotIn('login', strip_prompt_login(path2))
 
-        self.assertIn('prompt', AuthorizeView.strip_prompt_login(path3))
-        self.assertIn('none', AuthorizeView.strip_prompt_login(path3))
-        self.assertNotIn('login', AuthorizeView.strip_prompt_login(path3))
+        self.assertIn('prompt', strip_prompt_login(path3))
+        self.assertIn('none', strip_prompt_login(path3))
+        self.assertNotIn('login', strip_prompt_login(path3))
 
 
 class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):


### PR DESCRIPTION
AuthorizeView's static method strip-prompt-login was moved to a new file `oidc_provider/lib/utils/authorize.py` in order to be more consistent with the implementation of other Views.

Tests updated.