### PR TITLE
Enhancement: Increment RSA key size to 2048.

### DIFF
--- a/oidc_provider/management/commands/creatersakey.py
+++ b/oidc_provider/management/commands/creatersakey.py
@@ -1,6 +1,5 @@
 from Cryptodome.PublicKey import RSA
 from django.core.management.base import BaseCommand
-
 from oidc_provider.models import RSAKey
 
 
@@ -9,7 +8,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            key = RSA.generate(1024)
+            key = RSA.generate(2048)
             rsakey = RSAKey(key=key.exportKey('PEM').decode('utf8'))
             rsakey.save()
             self.stdout.write(u'RSA key successfully created with kid: {0}'.format(rsakey.kid))


### PR DESCRIPTION
It seems like many lead institutions related with security are
recommending a minimum key length of 112-bits since 2013.
In order to achieve that, a RSA key size of 2048 (or more) is required.