### PR TITLE
Fix example in docs for translatable scopes

### DIFF
--- a/docs/sections/scopesclaims.rst
+++ b/docs/sections/scopesclaims.rst
@@ -82,7 +82,7 @@ Somewhere in your Django ``settings.py``::
 
 Inside your oidc_provider_settings.py file add the following class::
 
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import ugettext_lazy as _
     from oidc_provider.lib.claims import ScopeClaims
 
     class CustomScopeClaims(ScopeClaims):


### PR DESCRIPTION
Since `_()` is evaluated at import time the translation would always be the default translation of the Django installation as of process startup time. With `ugettext_lazy` evaluation is delayed until the translated strings are forced to strings in the template, so the current language of the request will be used.