### PR TITLE
FEATURE: Add scope parameter to introspect response

### DIFF
--- a/oidc_provider/lib/endpoints/introspection.py
+++ b/oidc_provider/lib/endpoints/introspection.py
@@ -85,6 +85,7 @@ class TokenIntrospectionEndpoint(object):
                 response_dic[k] = self.id_token[k]
         response_dic['active'] = True
         response_dic['client_id'] = self.token.client.client_id
+        response_dic['scope'] = self.client.scope
 
         response_dic = run_processing_hook(response_dic,
                                            'OIDC_INTROSPECTION_PROCESSING_HOOK',

--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -55,11 +55,12 @@ def create_id_token(token, user, aud, nonce='', at_hash='', request=None, scope=
 
     # Inlude (or not) user standard claims in the id_token.
     if settings.get('OIDC_IDTOKEN_INCLUDE_CLAIMS'):
-        standard_claims = StandardScopeClaims(token)
-        dic.update(standard_claims.create_response_dic())
         if settings.get('OIDC_EXTRA_SCOPE_CLAIMS'):
             custom_claims = settings.get('OIDC_EXTRA_SCOPE_CLAIMS', import_str=True)(token)
-            dic.update(custom_claims.create_response_dic())
+            claims = custom_claims.create_response_dic()
+        else:
+            claims = StandardScopeClaims(token).create_response_dic()
+        dic.update(claims)
 
     dic = run_processing_hook(
         dic, 'OIDC_IDTOKEN_PROCESSING_HOOK',

--- a/oidc_provider/tests/cases/test_introspection_endpoint.py
+++ b/oidc_provider/tests/cases/test_introspection_endpoint.py
@@ -57,6 +57,7 @@ class IntrospectionTestCase(TestCase):
             'iat': int(self.now),
             'exp': int(self.now + 600),
             'iss': 'http://localhost:8000/openid',
+            'scope': self.resource.scope
         }
         expected_content.update(kwargs)
         self.assertJSONEqual(force_text(response.content), expected_content)
@@ -129,4 +130,5 @@ class IntrospectionTestCase(TestCase):
         self.assertJSONEqual(force_text(response.content), {
             'active': True,
             'client_id': self.client.client_id,
+            'scope': ['token_introspection']
         })


### PR DESCRIPTION
this adds "scope" to the response of the introspect endpoint.
some oauth clients (like django-oauth-toolkit) query and verifies the scope of the token
against the introspect endpoint.

The rfc7762 specifies the parameter scope as optional.
https://tools.ietf.org/html/rfc7662#section-2.2