### PR TITLE
Introspection fixes

### DIFF
--- a/oidc_provider/lib/endpoints/introspection.py
+++ b/oidc_provider/lib/endpoints/introspection.py
@@ -85,6 +85,7 @@ class TokenIntrospectionEndpoint(object):
                 response_dic[k] = self.id_token[k]
         response_dic['active'] = True
         response_dic['client_id'] = self.token.client.client_id
+        response_dic['scope'] = ' '.join(self.token.scope)
 
         response_dic = run_processing_hook(response_dic,
                                            'OIDC_INTROSPECTION_PROCESSING_HOOK',

--- a/oidc_provider/lib/endpoints/introspection.py
+++ b/oidc_provider/lib/endpoints/introspection.py
@@ -61,7 +61,7 @@ class TokenIntrospectionEndpoint(object):
 
         self.id_token = self.token.id_token
 
-        if settings.get('OIDC_INTROSPECTION_VALIDATE_AUDIENCE_SCOPE'):
+        if settings.get('OIDC_INTROSPECTION_VALIDATE_AUDIENCE_SCOPE') and self.token.user:
             if not self.token.id_token:
                 logger.debug('[Introspection] Token not an authentication token: %s',
                              self.params['token'])


### PR DESCRIPTION
When validating audience scope you check for the token to be an authentication token in line 65, but introspection is an OAuth2.0 spec (https://tools.ietf.org/html/rfc7662) meaning that you will have non related user token (when refering to client credentials grant). This validation is great but should be only for user related tokens.
On the other hand one of the purpose of introspection endpoint is to provide what rights of access the token carries adding scope to the members of the response should be included. https://tools.ietf.org/html/rfc7662#section-2.2