### PR TITLE
Handle form post response mode

### DIFF
--- a/oidc_provider/lib/endpoints/authorize.py
+++ b/oidc_provider/lib/endpoints/authorize.py
@@ -51,7 +51,7 @@ class AuthorizeEndpoint(object):
         elif self.params['response_type'] in ['id_token', 'id_token token', 'token']:
             self.grant_type = 'implicit'
         elif self.params['response_type'] in [
-             'code token', 'code id_token', 'code id_token token']:
+                'code token', 'code id_token', 'code id_token token']:
             self.grant_type = 'hybrid'
         else:
             self.grant_type = None
@@ -233,14 +233,17 @@ class AuthorizeEndpoint(object):
         Return dict of context for `form_post.html`
 
         Returns dict:
-            - params: dict of key:value for hidden form_post fields
+            - params: dict of key: value for hidden form_post fields
             - redirect_url: url for form action
         """
-        params = parse_qs(urlsplit(uri).fragment)
+        split_uri = urlsplit(uri)
+        frag = parse_qs(split_uri.fragment)
+        query = parse_qs(split_uri.query)
+        params = frag if frag else query
         params = {key: value[0] for key, value in params.items()}
         dic = {'redirect_url': self.params['redirect_uri']}
         dic['params'] = params
-        logger.debug("forum_post dict: %s", dic)
+        logger.debug("form_post dict: %s", dic)
         return dic
 
     def set_client_user_consent(self):

--- a/oidc_provider/lib/endpoints/authorize.py
+++ b/oidc_provider/lib/endpoints/authorize.py
@@ -243,7 +243,6 @@ class AuthorizeEndpoint(object):
         params = {key: value[0] for key, value in params.items()}
         dic = {'redirect_url': self.params['redirect_uri']}
         dic['params'] = params
-        logger.debug("form_post dict: %s", dic)
         return dic
 
     def set_client_user_consent(self):

--- a/oidc_provider/lib/endpoints/authorize.py
+++ b/oidc_provider/lib/endpoints/authorize.py
@@ -77,6 +77,7 @@ class AuthorizeEndpoint(object):
         self.params['scope'] = query_dict.get('scope', '').split()
         self.params['state'] = query_dict.get('state', '')
         self.params['nonce'] = query_dict.get('nonce', '')
+        self.params['response_mode'] = query_dict.get('response_mode', '')
 
         self.params['prompt'] = self._allowed_prompt_params.intersection(
             set(query_dict.get('prompt', '').split()))
@@ -226,6 +227,19 @@ class AuthorizeEndpoint(object):
             fragment=uri.fragment + urlencode(query_fragment, doseq=True))
 
         return urlunsplit(uri)
+
+    def get_form_post_context(self, uri):
+        """
+        Return dict of context for `form_post.html`
+
+        Returns dict:
+            - params: dict of key:value for hidden form_post fields
+            - redirect_url: url for form action
+        """
+        params = parse_qs(urlsplit(uri).fragment)
+        dic = {'redirect_url': self.params['redirect_uri']}
+        dic['params'] = params
+        return dic
 
     def set_client_user_consent(self):
         """

--- a/oidc_provider/lib/endpoints/authorize.py
+++ b/oidc_provider/lib/endpoints/authorize.py
@@ -237,8 +237,10 @@ class AuthorizeEndpoint(object):
             - redirect_url: url for form action
         """
         params = parse_qs(urlsplit(uri).fragment)
+        params = {key: value[0] for key, value in params.items()}
         dic = {'redirect_url': self.params['redirect_uri']}
         dic['params'] = params
+        logger.debug("forum_post dict: %s", dic)
         return dic
 
     def set_client_user_consent(self):

--- a/oidc_provider/settings.py
+++ b/oidc_provider/settings.py
@@ -165,7 +165,8 @@ class DefaultSettings(object):
     def OIDC_TEMPLATES(self):
         return {
             'authorize': 'oidc_provider/authorize.html',
-            'error': 'oidc_provider/error.html'
+            'error': 'oidc_provider/error.html',
+            'form_post': 'oidc_provider/form_post.html',
         }
 
     @property

--- a/oidc_provider/templates/oidc_provider/form_post.html
+++ b/oidc_provider/templates/oidc_provider/form_post.html
@@ -4,7 +4,7 @@
         <form method="post" action="{{ redirect_url }}" name="form">
             {% csrf_token %}
             {% for field, value in params.items %}
-                <input type="hidden" name="{{ field }}" value="{{ value.0 }}" />
+                <input type="hidden" name="{{ field }}" value="{{ value }}" />
             {% endfor %}
         </form>
 

--- a/oidc_provider/templates/oidc_provider/form_post.html
+++ b/oidc_provider/templates/oidc_provider/form_post.html
@@ -1,0 +1,12 @@
+<html>
+    <body onload="document.form.submit();">
+        form post
+        <form method="post" action="{{ redirect_url }}" name="form">
+            {% csrf_token %}
+            {% for field, value in params.items %}
+                <input type="hidden" name="{{ field }}" value="{{ value.0 }}" />
+            {% endfor %}
+        </form>
+
+    </body>
+</html>

--- a/oidc_provider/tests/cases/test_authorize_endpoint.py
+++ b/oidc_provider/tests/cases/test_authorize_endpoint.py
@@ -506,7 +506,7 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
     This will render a template with variables as input fields and then
     autosubmit the form via javascript
-    
+
     https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html#FormPostResponseMode
     """
 
@@ -540,11 +540,11 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
         response = self._auth_request('get', data, is_user_authenticated=True)
 
-        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]), 
+        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state), 
+        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="code" value='.format(self.state), 
+        self.assertIn('<input type="hidden" name="code" value='.format(self.state),
                       response.content.decode('utf-8'))
 
     def test_success_via_post(self):
@@ -565,11 +565,11 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
         response = self._auth_request('post', data, is_user_authenticated=True)
 
-        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]), 
+        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state), 
+        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="code" value='.format(self.state), 
+        self.assertIn('<input type="hidden" name="code" value='.format(self.state),
                       response.content.decode('utf-8'))
 
     def test_error_via_get(self):
@@ -594,9 +594,9 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
         response = self._auth_request('get', data, is_user_authenticated=True)
 
-        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]), 
+        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state), 
+        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state),
                       response.content.decode('utf-8'))
         self.assertIn('<input type="hidden" name="error" value=',
                       response.content.decode('utf-8'))
@@ -607,7 +607,7 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
     def test_user_declines_via_post(self):
         """
-        If error user does not consent when response_mode=form_post via POST 
+        If error user does not consent when response_mode=form_post via POST
         at authorize, the response_mode should be honored
 
         https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#MultiValueResponseTypes
@@ -625,9 +625,9 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
         response = self._auth_request('post', data, is_user_authenticated=True)
 
-        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]), 
+        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state), 
+        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state),
                       response.content.decode('utf-8'))
         self.assertIn('<input type="hidden" name="error" value=',
                       response.content.decode('utf-8'))
@@ -657,9 +657,9 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
         response = self._auth_request('post', data, is_user_authenticated=True)
 
-        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]), 
+        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state), 
+        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state),
                       response.content.decode('utf-8'))
         self.assertIn('<input type="hidden" name="error" value=',
                       response.content.decode('utf-8'))
@@ -670,7 +670,7 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
     def test_success_get_reuse_consent(self):
         """
-        Test with response_mode=form_post via GET to authorize when reusing 
+        Test with response_mode=form_post via GET to authorize when reusing
         consent
         """
 
@@ -690,22 +690,22 @@ class TestAuthorizeResponseModeFormPost(TestCase, AuthorizeEndpointMixin):
 
         response = self._auth_request('post', data, is_user_authenticated=True)
 
-        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]), 
+        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state), 
+        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="code" value='.format(self.state), 
+        self.assertIn('<input type="hidden" name="code" value='.format(self.state),
                       response.content.decode('utf-8'))
 
         del data['allow']
 
         response = self._auth_request('get', data, is_user_authenticated=True)
 
-        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]), 
+        self.assertIn('action="{}"'.format(self.client.redirect_uris[0]),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state), 
+        self.assertIn('<input type="hidden" name="state" value="{}" />'.format(self.state),
                       response.content.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="code" value='.format(self.state), 
+        self.assertIn('<input type="hidden" name="code" value='.format(self.state),
                       response.content.decode('utf-8'))
 
 

--- a/oidc_provider/tests/cases/test_authorize_endpoint.py
+++ b/oidc_provider/tests/cases/test_authorize_endpoint.py
@@ -1,6 +1,4 @@
-import pytest
 from oidc_provider.lib.errors import RedirectUriError
-import logging
 
 try:
     from urllib.parse import urlencode, quote
@@ -21,7 +19,7 @@ except ImportError:
     from django.core.urlresolvers import reverse
 from django.test import (
     RequestFactory,
-    override_settings
+    override_settings,
 )
 from django.test import TestCase
 from jwkest.jwt import JWT
@@ -36,8 +34,6 @@ from oidc_provider.tests.app.utils import (
 from oidc_provider.lib.utils.authorize import strip_prompt_login
 from oidc_provider.views import AuthorizeView
 from oidc_provider.lib.endpoints.authorize import AuthorizeEndpoint
-
-log = logging.getLogger(__name__)
 
 
 class AuthorizeEndpointMixin(object):

--- a/oidc_provider/tests/cases/test_settings.py
+++ b/oidc_provider/tests/cases/test_settings.py
@@ -4,7 +4,8 @@ from oidc_provider import settings
 
 CUSTOM_TEMPLATES = {
     'authorize': 'custom/authorize.html',
-    'error': 'custom/error.html'
+    'error': 'custom/error.html',
+    'form_post': 'custom/form_post.html',
 }
 
 

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -157,6 +157,7 @@ class AuthorizeView(View):
                 return render(request, OIDC_TEMPLATES['authorize'], context)
             else:
                 if 'none' in authorize.params['prompt']:
+                    logger.info('prompt is None')
                     raise AuthorizeError(
                         authorize.params['redirect_uri'], 'login_required', authorize.grant_type)
                 if 'login' in authorize.params['prompt']:
@@ -177,6 +178,12 @@ class AuthorizeView(View):
             uri = error.create_uri(
                 authorize.params['redirect_uri'],
                 authorize.params['state'])
+
+            if authorize.params['response_mode'] == 'form_post':
+                return render(
+                    request,
+                    OIDC_TEMPLATES['form_post'],
+                    authorize.get_form_post_context(uri))
 
             return redirect(uri)
 
@@ -215,6 +222,12 @@ class AuthorizeView(View):
             uri = error.create_uri(
                 authorize.params['redirect_uri'],
                 authorize.params['state'])
+
+            if authorize.params['response_mode'] == 'form_post':
+                return render(
+                    request,
+                    OIDC_TEMPLATES['form_post'],
+                    authorize.get_form_post_context(uri))
 
             return redirect(uri)
 

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -111,14 +111,26 @@ class AuthorizeView(View):
                 if not authorize.client.require_consent and (
                         allow_skipping_consent and
                         'consent' not in authorize.params['prompt']):
-                    return redirect(authorize.create_response_uri())
+                    response_uri = authorize.create_response_uri()
+                    if authorize.params['response_mode'] == 'form_post':
+                        return render(
+                            request,
+                            OIDC_TEMPLATES['form_post'],
+                            authorize.get_form_post_context(response_uri))
+                    return redirect(response_uri)
 
                 if authorize.client.reuse_consent:
                     # Check if user previously give consent.
                     if authorize.client_has_user_consent() and (
                             allow_skipping_consent and
                             'consent' not in authorize.params['prompt']):
-                        return redirect(authorize.create_response_uri())
+                        response_uri = authorize.create_response_uri()
+                        if authorize.params['response_mode'] == 'form_post':
+                            return render(
+                                request,
+                                OIDC_TEMPLATES['form_post'],
+                                authorize.get_form_post_context(response_uri))
+                        return redirect(response_uri)
 
                 if 'none' in authorize.params['prompt']:
                     raise AuthorizeError(
@@ -230,6 +242,7 @@ def userinfo(request, *args, **kwargs):
 
     Return a dictionary.
     """
+    logger.info("userinfo hit")
 
     def set_headers(response):
         response['Cache-Control'] = 'no-store'

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -203,6 +203,11 @@ class AuthorizeView(View):
             authorize.set_client_user_consent()
 
             uri = authorize.create_response_uri()
+            if authorize.params['response_mode'] == 'form_post':
+                return render(
+                    request,
+                    OIDC_TEMPLATES['form_post'],
+                    authorize.get_form_post_context(uri))
 
             return redirect(uri)
 

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -157,7 +157,6 @@ class AuthorizeView(View):
                 return render(request, OIDC_TEMPLATES['authorize'], context)
             else:
                 if 'none' in authorize.params['prompt']:
-                    logger.info('prompt is None')
                     raise AuthorizeError(
                         authorize.params['redirect_uri'], 'login_required', authorize.grant_type)
                 if 'login' in authorize.params['prompt']:

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -242,7 +242,6 @@ def userinfo(request, *args, **kwargs):
 
     Return a dictionary.
     """
-    logger.info("userinfo hit")
 
     def set_headers(response):
         response['Cache-Control'] = 'no-store'


### PR DESCRIPTION
Implements #335

* Handles the response_mode="form_post" case.
* Does not handle the fragment or query response modes.
* Honors the form_post response mode on success or errors.
* Test cases for success and error cases

I implemented this in `AuthorizeView.post` as well. Hopefully I interpreted that correctly! Thanks!