### PR TITLE
fix  models related_name='+'

### DIFF
--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -185,7 +185,7 @@ class BaseCodeTokenModel(models.Model):
 class Code(BaseCodeTokenModel):
 
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, verbose_name=_(u'User'), on_delete=models.CASCADE)
+        settings.AUTH_USER_MODEL, verbose_name=_(u'User'), on_delete=models.CASCADE, related_name='+')
     code = models.CharField(max_length=255, unique=True, verbose_name=_(u'Code'))
     nonce = models.CharField(max_length=255, blank=True, default='', verbose_name=_(u'Nonce'))
     is_authentication = models.BooleanField(default=False, verbose_name=_(u'Is Authentication?'))
@@ -204,7 +204,7 @@ class Code(BaseCodeTokenModel):
 class Token(BaseCodeTokenModel):
 
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, null=True, verbose_name=_(u'User'), on_delete=models.CASCADE)
+        settings.AUTH_USER_MODEL, null=True, verbose_name=_(u'User'), on_delete=models.CASCADE, related_name='+')
     access_token = models.CharField(max_length=255, unique=True, verbose_name=_(u'Access Token'))
     refresh_token = models.CharField(max_length=255, unique=True, verbose_name=_(u'Refresh Token'))
     _id_token = models.TextField(verbose_name=_(u'ID Token'))


### PR DESCRIPTION
I can't migrate in some error.
SystemCheckError: System check identified some issues:
ERRORS:
oidc_provider.Code.user: (fields.E303) Reverse query name for 'Code.user' clashes with field name 'Account.code'.
	HINT: Rename field 'Account.code', or add/change a related_name argument to the definition for field 'Code.user'.
oidc_provider.Token.user: (fields.E303) Reverse query name for 'Token.user' clashes with field name 'Account.token'.
	HINT: Rename field 'Account.token', or add/change a related_name argument to the definition for field 'Token.user'.