### PR TITLE
Allow setting a custom TokenEndpoint class

### DIFF
--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -203,8 +203,10 @@ class AuthorizeView(View):
 
 
 class TokenView(View):
+    token_endpoint_class = TokenEndpoint
+
     def post(self, request, *args, **kwargs):
-        token = TokenEndpoint(request)
+        token = self.token_endpoint_class(request)
 
         try:
             token.validate_params()


### PR DESCRIPTION
If for whatever reason you want to change the `TokenEndpoint` class used on `TokenView`, you now need to completely overwrite the `post` method. This PR allows you to overwrite it without taking over the `TokenView` completely, using a variable called `token_endpoint_class`. 

This change is in line with how `AuthorizeView` works with `AuthorizeEndpoint` through `authorize_endpoint_class`. 