### PR TITLE
Read-only KeyError within ClientForm fixed

### DIFF
--- a/oidc_provider/admin.py
+++ b/oidc_provider/admin.py
@@ -17,10 +17,12 @@ class ClientForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ClientForm, self).__init__(*args, **kwargs)
-        self.fields['client_id'].required = False
-        self.fields['client_id'].widget.attrs['disabled'] = 'true'
-        self.fields['client_secret'].required = False
-        self.fields['client_secret'].widget.attrs['disabled'] = 'true'
+        if 'client_id' in self.fields:
+            self.fields['client_id'].required = False
+            self.fields['client_id'].widget.attrs['disabled'] = 'true'
+        if 'client_secret' in self.fields:
+            self.fields['client_secret'].required = False
+            self.fields['client_secret'].widget.attrs['disabled'] = 'true'
 
     def clean_client_id(self):
         instance = getattr(self, 'instance', None)


### PR DESCRIPTION
Issue: https://github.com/juanifioren/django-oidc-provider/issues/365

`ClientForm.fields` can be empty (and is always empty when the form is accessed with can view permission only). In such scenario, accessing this dict within line 20 in **oidc_provider/admin.py** will raise the KeyError.

Here is a straight forward **quick-fix** for the issue.