### PR TITLE
Fix ResponseType data migration

### DIFF
--- a/oidc_provider/migrations/0026_client_multiple_response_types.py
+++ b/oidc_provider/migrations/0026_client_multiple_response_types.py
@@ -16,10 +16,11 @@ def migrate_response_type(apps, schema_editor):
     # importing directly yields the latest without response_type
     ResponseType = apps.get_model('oidc_provider', 'ResponseType')
     Client = apps.get_model('oidc_provider', 'Client')
+    db = schema_editor.connection.alias
     for value, description in RESPONSE_TYPES:
-        ResponseType.objects.create(value=value, description=description)
-    for client in Client.objects.all():
-        client.response_types.add(ResponseType.objects.get(value=client.response_type))
+        ResponseType.objects.using(db).create(value=value, description=description)
+    for client in Client.objects.using(db).all():
+        client.response_types.add(ResponseType.objects.using(db).get(value=client.response_type))
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
If oidc provider is used in a multi database setup it may not be used on
the default database alone. And when used in a database mirror setup the
migration could be executed on a different db alias/transaction.

This can cause migration failures because the ReponseType table is
created on the database passed to the migrate command while the data is
inserted in the database returned from the database router.
Depending on the configuration the ResponseType table may not exist for
that database yet or the ResponseType data was already migrated
resulting in a DatabaseError and IntegrityError respectively.