### PR TITLE
fix delete userinfo table migration

### DIFF
--- a/oidc_provider/migrations/0004_remove_userinfo.py
+++ b/oidc_provider/migrations/0004_remove_userinfo.py
@@ -11,10 +11,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='userinfo',
-            name='user',
-        ),
         migrations.DeleteModel(
             name='UserInfo',
         ),


### PR DESCRIPTION
The original migration does not work for cockroachdb and fails with
`django.db.utils.ProgrammingError: column "user_id" is referenced by the primary key`
After this change, it works well. 
Tested with postgresql and cockroachdb