### PR TITLE
chore: Update tox with new matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist=
     docs,
-    py27-django{111},
-    py35-django{111,20,21},
-    py36-django{111,20,21},
+    py36-django{22},
+    py38-django{22,31},
 
 [testenv]
 changedir=
@@ -15,15 +14,15 @@ deps =
     pytest-django
     pytest-flake8
     pytest-cov
-    django111: django>=1.11,<1.12
-    django20: django>=2.0,<2.1
-    django21: django>=2.1,<2.2
+    django22: django>=2.2,<2.3
+    django30: django>=3.0,<3.1
+    django31: django>=3.1,<3.2
 
 commands =
     pytest --flake8 --cov=oidc_provider {posargs}
 
 [testenv:docs]
-basepython = python2.7
+basepython = python3.6
 changedir = docs
 whitelist_externals =
     mkdir


### PR DESCRIPTION
Drop unsupported django releases from matrix