### PR TITLE
Django 4 signals don't have argument providing_args

### DIFF
--- a/oidc_provider/signals.py
+++ b/oidc_provider/signals.py
@@ -2,5 +2,5 @@
 from django.dispatch import Signal
 
 
-user_accept_consent = Signal(providing_args=['user', 'client', 'scope'])
-user_decline_consent = Signal(providing_args=['user', 'client', 'scope'])
+user_accept_consent = Signal()
+user_decline_consent = Signal()


### PR DESCRIPTION
See [here](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0).