### PR TITLE
fix race condition on code exchange for token

### DIFF
--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -71,7 +71,8 @@ class TokenEndpoint(object):
                 raise TokenError('invalid_client')
 
             try:
-                self.code = Code.objects.select_for_update(nowait=True).get(code=self.params['code'])
+                self.code = Code.objects.select_for_update(nowait=True).get(
+                    code=self.params['code'])
             except DatabaseError:
                 logger.debug('[Token] Code cannot be reused: %s', self.params['code'])
                 raise TokenError('invalid_grant')

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -18,6 +18,7 @@ try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
+from django.db import transaction
 from django.contrib.auth import logout as django_user_logout
 from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render
@@ -204,9 +205,9 @@ class TokenView(View):
         token = self.token_endpoint_class(request)
 
         try:
-            token.validate_params()
-
-            dic = token.create_response_dic()
+            with transaction.atomic():
+                token.validate_params()
+                dic = token.create_response_dic()
 
             return self.token_endpoint_class.response(dic)
 


### PR DESCRIPTION
During token exchange where an authorization code is exchanged for an access token and a refresh token, the same code can be used more than once. This happens if more requests are issued in parallel.

This PR adds a `.select_for_update` so only the first attempt goes through.

Fixes #410.