### PR TITLE
default_app_config is deprecated in django 4+

### DIFF
--- a/oidc_provider/__init__.py
+++ b/oidc_provider/__init__.py
@@ -1,2 +1,4 @@
+import django
 
-default_app_config = 'oidc_provider.apps.OIDCProviderConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'oidc_provider.apps.OIDCProviderConfig'


### PR DESCRIPTION
`default_app_config` is now deprecated and django auto-discovers it:

https://code.djangoproject.com/ticket/31180