### PR TITLE
Replace ResponseType model with a json field (1)

### DIFF
--- a/docs/sections/changelog.rst
+++ b/docs/sections/changelog.rst
@@ -14,6 +14,7 @@ Unreleased
 * Changed: Django 5 added to test matrix.
 * Changed: ID Token JSON encoder improved using DjangoJSONEncoder.
 * Changed: Use unittest.mock in tests. Remove mock library.
+* Changed: Switch Client.response_types to be a JSONField instead of a ManyToManyField. (Run migrations!)
 
 0.8.3
 =====

--- a/oidc_provider/fields.py
+++ b/oidc_provider/fields.py
@@ -1,0 +1,121 @@
+import copy
+
+from django import forms
+from django.core import exceptions
+from django.db import models
+
+__all__ = ["JSONMultiSelectModelField"]
+
+
+class MultipleChoiceFormField(forms.MultipleChoiceField):
+    def __init__(self, *args, **kwargs):
+        # Django admin calls this field with the coerce parameter, but MultipleChoiceField
+        # does not handle it. We don't need it anyway.
+        kwargs.pop("coerce", None)
+        super(MultipleChoiceFormField, self).__init__(*args, **kwargs)
+
+    def to_python(self, value):
+        # MultipleChoiceField can't handle value being a set. Give it a tuple.
+        if isinstance(value, set):
+            value = tuple(value)
+        return super(MultipleChoiceFormField, self).to_python(value)
+
+    def prepare_value(self, value):
+        # MultipleChoiceField can't handle value being a set. Give it a tuple.
+        if value is None:
+            return value
+        return tuple(value)
+
+
+class JSONMultiSelectModelField(models.JSONField):
+    """
+    A field that is used to select multiple choices from a static set of choices.
+    In python code it is represented as a set containing string identifiers for
+    the selected values.
+    At database level it is saved as a list of string identifiers using djangos
+    JSONField.
+    On forms it appears as multiple checkboxes.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs["default"] = set
+        super().__init__(*args, **kwargs)
+
+    def from_db_value(self, value, expression, connection):
+        value = super().from_db_value(value, expression, connection)
+        return self.to_python(value)
+
+    def to_python(self, value):
+        value = super().to_python(value)
+        if isinstance(value, set) or value is None:
+            return value
+        elif isinstance(value, list):
+            return set(value)
+        return value
+
+    def value_from_object(self, obj):
+        """
+        Returns the value of this field as currently set on the model instance.
+        """
+        value = super().value_from_object(obj)
+        return self.to_python(value)
+
+    def get_prep_value(self, value):
+        # Used when saving to db
+        db_value = super().get_prep_value(list(value))
+        if db_value is None:
+            return db_value
+        return db_value
+
+    def value_to_string(self, obj):
+        # Used when serialising (dumpdata)
+        value = self.value_from_object(obj)
+        return self.get_prep_value(value)
+
+    def formfield(self, **kwargs):
+        defaults = {
+            "choices_form_class": MultipleChoiceFormField,
+            "widget": forms.CheckboxSelectMultiple,
+        }
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
+
+    def validate(self, value, model_instance):
+        """
+        Validates that all the selected choices are valid choices.
+        """
+        if not self.editable:
+            # Skip validation for non-editable fields.
+            return
+
+        if self.choices and value not in self.empty_values:
+            allowed_choices = [key for key, description in self.choices]
+            for item in value:
+                if item not in allowed_choices:
+                    raise exceptions.ValidationError(
+                        self.error_messages["invalid_choice"],
+                        code="invalid_choice",
+                        params={"value": item},
+                    )
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        # We don't need anything about our custom field in the context of the migration.
+        # It keep things much simpler, if the migrations think this is just a boring
+        # plain old JSONField.
+        # See `def clone()` for more information.
+        path = "django.db.models.JSONField"
+        return name, path, args, kwargs
+
+    def clone(self):
+        name, path, args, kwargs = self.deconstruct()
+        # Usually the Field base class would do `self.__class__(*args, **kwargs)` here.
+        # However we want to pretend to migrations that we're just a normal JSONField,
+        # so that is what we return here.
+        # We also remove a bunch of kwargs that are not relevant in the migrations.
+        kwargs = copy.deepcopy(kwargs)
+        kwargs.pop("verbose_name", None)
+        kwargs.pop("help_text", None)
+        kwargs.pop("choices", None)
+        kwargs["default"] = list
+        return models.JSONField(*args, **kwargs)

--- a/oidc_provider/migrations/0028_change_response_types_field_1_of_3.py
+++ b/oidc_provider/migrations/0028_change_response_types_field_1_of_3.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oidc_provider", "0027_alter_rsakey_options"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="client",
+            old_name="response_types",
+            new_name="old_response_types",
+        ),
+        migrations.AddField(
+            model_name="client",
+            name="response_types",
+            field=models.JSONField(default=list),
+        ),
+    ]

--- a/oidc_provider/migrations/0029_change_response_types_field_2_of_3.py
+++ b/oidc_provider/migrations/0029_change_response_types_field_2_of_3.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+def migrate_response_type(apps, schema_editor):
+    Client = apps.get_model("oidc_provider", "Client")
+    for client in Client.objects.all():
+        client.response_types = [
+            str(value) for value in client.old_response_types.values_list("value", flat=True)
+        ]
+        client.save()
+
+
+def migrate_response_type_back_to_model(apps, schema_editor):
+    Client = apps.get_model("oidc_provider", "Client")
+    ResponseType = apps.get_model("oidc_provider", "ResponseType")
+    RESPONSE_TYPES = [
+        ("code", "code (Authorization Code Flow)"),
+        ("id_token", "id_token (Implicit Flow)"),
+        ("id_token token", "id_token token (Implicit Flow)"),
+        ("code token", "code token (Hybrid Flow)"),
+        ("code id_token", "code id_token (Hybrid Flow)"),
+        ("code id_token token", "code id_token token (Hybrid Flow)"),
+    ]
+    # ensure we get proper, versioned model with the deleted response_type field;
+    # importing directly yields the latest without response_type
+    for value, description in RESPONSE_TYPES:
+        ResponseType.objects.create(value=value, description=description)
+    for client in Client.objects.all():
+        client.old_response_types.set(
+            list(ResponseType.objects.filter(value__in=client.response_types))
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oidc_provider", "0028_change_response_types_field_1_of_3"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_response_type, reverse_code=migrate_response_type_back_to_model
+        ),
+    ]

--- a/oidc_provider/migrations/0030_change_response_types_field_3_of_3.py
+++ b/oidc_provider/migrations/0030_change_response_types_field_3_of_3.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oidc_provider", "0029_change_response_types_field_2_of_3"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="client",
+            name="old_response_types",
+        ),
+        migrations.DeleteModel(
+            name="ResponseType",
+        ),
+    ]

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -10,6 +10,8 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from oidc_provider.fields import JSONMultiSelectModelField
+
 CLIENT_TYPE_CHOICES = [
     ("confidential", "Confidential"),
     ("public", "Public"),
@@ -28,31 +30,6 @@ JWT_ALGS = [
     ("HS256", "HS256"),
     ("RS256", "RS256"),
 ]
-
-
-class ResponseTypeManager(models.Manager):
-    def get_by_natural_key(self, value):
-        return self.get(value=value)
-
-
-class ResponseType(models.Model):
-    objects = ResponseTypeManager()
-
-    value = models.CharField(
-        max_length=30,
-        choices=RESPONSE_TYPE_CHOICES,
-        unique=True,
-        verbose_name=_("Response Type Value"),
-    )
-    description = models.CharField(
-        max_length=50,
-    )
-
-    def natural_key(self):
-        return (self.value,)  # natural_key must return tuple
-
-    def __str__(self):
-        return "{0}".format(self.description)
 
 
 class Client(models.Model):
@@ -78,7 +55,9 @@ class Client(models.Model):
     )
     client_id = models.CharField(max_length=255, unique=True, verbose_name=_("Client ID"))
     client_secret = models.CharField(max_length=255, blank=True, verbose_name=_("Client SECRET"))
-    response_types = models.ManyToManyField(ResponseType)
+    response_types = JSONMultiSelectModelField(
+        choices=RESPONSE_TYPE_CHOICES, verbose_name=_("Response Types")
+    )
     jwt_alg = models.CharField(
         max_length=10,
         choices=JWT_ALGS,
@@ -143,11 +122,13 @@ class Client(models.Model):
         return self.__str__()
 
     def response_type_values(self):
-        return (response_type.value for response_type in self.response_types.all())
+        # Return the allowed response types in the same order as they appear in
+        # RESPONSE_TYPE_CHOICES.
+        return [code for code, description in RESPONSE_TYPE_CHOICES if code in self.response_types]
 
     def response_type_descriptions(self):
-        # return as a list, rather than a generator, so descriptions display correctly in admin
-        return [response_type.description for response_type in self.response_types.all()]
+        response_type_dict = dict(RESPONSE_TYPE_CHOICES)
+        return [response_type_dict[response_type] for response_type in self.response_type_values()]
 
     @property
     def redirect_uris(self):

--- a/oidc_provider/tests/app/utils.py
+++ b/oidc_provider/tests/app/utils.py
@@ -17,7 +17,6 @@ from django.utils import timezone
 from oidc_provider.lib.claims import ScopeClaims
 from oidc_provider.models import Client
 from oidc_provider.models import Code
-from oidc_provider.models import ResponseType
 from oidc_provider.models import Token
 
 FAKE_NONCE = "cb584e44c43ed6bd0bc2d9c7e242837d"
@@ -71,8 +70,8 @@ def create_fake_client(response_type, is_public=False, require_consent=True):
     if isinstance(response_type, ("".__class__, "".__class__)):
         response_type = (response_type,)
     for value in response_type:
-        client.response_types.add(ResponseType.objects.get(value=value))
-
+        client.response_types.add(value)
+    client.save()
     return client
 
 

--- a/oidc_provider/tests/cases/test_authorize_endpoint.py
+++ b/oidc_provider/tests/cases/test_authorize_endpoint.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     from urlparse import parse_qs
     from urlparse import urlsplit
+
 import uuid
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -22,6 +23,7 @@ try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
+
 from django.contrib.auth.models import AnonymousUser
 from django.core.management import call_command
 from django.test import RequestFactory
@@ -385,7 +387,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
         """
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -412,7 +414,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
         """
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -444,7 +446,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
         """
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -466,7 +468,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
         """
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -488,7 +490,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
         """
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -516,7 +518,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
 
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -541,7 +543,7 @@ class AuthorizationCodeFlowTestCase(TestCase, AuthorizeEndpointMixin):
 
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -612,7 +614,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         """
         data = {
             "client_id": self.client_code.client_id,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "redirect_uri": self.client_code.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -630,7 +632,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         data = {
             "client_id": self.client_code.client_id,
             "redirect_uri": self.client_code.default_redirect_uri,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "scope": "openid email",
             "state": self.state,
             "nonce": self.nonce,
@@ -645,7 +647,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         # same for public client
         data["client_id"] = (self.client_public.client_id,)
         data["redirect_uri"] = (self.client_public.default_redirect_uri,)
-        data["response_type"] = (next(self.client_public.response_type_values()),)
+        data["response_type"] = (self.client_public.response_type_values()[0],)
 
         response = self._auth_request("post", data, is_user_authenticated=True)
 
@@ -660,7 +662,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         data = {
             "client_id": self.client_no_access.client_id,
             "redirect_uri": self.client_no_access.default_redirect_uri,
-            "response_type": next(self.client_no_access.response_type_values()),
+            "response_type": self.client_no_access.response_type_values()[0],
             "scope": "openid email",
             "state": self.state,
             "nonce": self.nonce,
@@ -675,7 +677,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         # same for public client
         data["client_id"] = (self.client_public_no_access.client_id,)
         data["redirect_uri"] = (self.client_public_no_access.default_redirect_uri,)
-        data["response_type"] = (next(self.client_public_no_access.response_type_values()),)
+        data["response_type"] = (self.client_public_no_access.response_type_values()[0],)
 
         response = self._auth_request("post", data, is_user_authenticated=True)
 
@@ -690,7 +692,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         data = {
             "client_id": self.client_code.client_id,
             "redirect_uri": self.client_code.default_redirect_uri,
-            "response_type": next(self.client_code.response_type_values()),
+            "response_type": self.client_code.response_type_values()[0],
             "scope": "openid email",
             "state": self.state,
             "nonce": self.nonce,
@@ -716,7 +718,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         data = {
             "client_id": self.client_no_access.client_id,
             "redirect_uri": self.client_no_access.default_redirect_uri,
-            "response_type": next(self.client_no_access.response_type_values()),
+            "response_type": self.client_no_access.response_type_values()[0],
             "scope": "openid email",
             "state": self.state,
             "nonce": self.nonce,
@@ -740,7 +742,7 @@ class AuthorizationImplicitFlowTestCase(TestCase, AuthorizeEndpointMixin):
         """
         data = {
             "client_id": self.client_public_no_consent.client_id,
-            "response_type": next(self.client_public_no_consent.response_type_values()),
+            "response_type": self.client_public_no_consent.response_type_values()[0],
             "redirect_uri": self.client_public_no_consent.default_redirect_uri,
             "scope": "openid email",
             "state": self.state,
@@ -803,7 +805,7 @@ class AuthorizationHybridFlowTestCase(TestCase, AuthorizeEndpointMixin):
         self.data = {
             "client_id": self.client_code_idtoken_token.client_id,
             "redirect_uri": self.client_code_idtoken_token.default_redirect_uri,
-            "response_type": next(self.client_code_idtoken_token.response_type_values()),
+            "response_type": self.client_code_idtoken_token.response_type_values()[0],
             "scope": "openid email",
             "state": self.state,
             "nonce": self.nonce,
@@ -849,7 +851,7 @@ class TestCreateResponseURI(TestCase):
         data = {
             "client_id": client.client_id,
             "redirect_uri": client.default_redirect_uri,
-            "response_type": next(client.response_type_values()),
+            "response_type": client.response_type_values()[0],
         }
 
         factory = RequestFactory()

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -57,8 +57,8 @@ from oidc_provider.lib.utils.common import redirect
 from oidc_provider.lib.utils.oauth2 import protected_resource_view
 from oidc_provider.lib.utils.token import client_id_from_id_token
 from oidc_provider.models import Client
-from oidc_provider.models import ResponseType
 from oidc_provider.models import RSAKey
+from oidc_provider.models import RESPONSE_TYPE_CHOICES
 
 logger = logging.getLogger(__name__)
 
@@ -276,16 +276,6 @@ def userinfo(request, *args, **kwargs):
 
 
 class ProviderInfoView(View):
-    _types_supported = None
-
-    @property
-    def types_supported(self):
-        if self._types_supported is None:
-            self._types_supported = [
-                response_type.value for response_type in ResponseType.objects.all()
-            ]
-        return self._types_supported
-
     def _build_response_dict(self, request):
         dic = dict()
 
@@ -298,7 +288,7 @@ class ProviderInfoView(View):
         dic["end_session_endpoint"] = site_url + reverse("oidc_provider:end-session")
         dic["introspection_endpoint"] = site_url + reverse("oidc_provider:token-introspection")
 
-        dic["response_types_supported"] = self.types_supported
+        dic["response_types_supported"] = [code for code, _description in RESPONSE_TYPE_CHOICES]
 
         dic["jwks_uri"] = site_url + reverse("oidc_provider:jwks")
 


### PR DESCRIPTION
Replace the `ResponseType` model with a JSONField

Instead of using a `ResponseType` model and a `ManyToMany` relationship to `Client`, use a custom field that saves the selected `response_types` in a `JSONField`.

This simplifies the model structure and doesn't require keeping the db in-sync with code, since the `response_types` are a static set of choices anyway.

It also has the benefit of a nicer UI in django admin:
![image](https://github.com/user-attachments/assets/a6e6780b-d574-4cd7-9567-b6fae8b9e0c4)
