### PR TITLE
Run tests in matrix on github

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,16 @@
-name: Django Tests CI
-
+name: "CI"
 on:
   push:
     branches: ["master", "develop"]
   pull_request:
-    branches: ["develop"]
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   formatting:
+    name: "Check Code Formatting"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,6 +20,7 @@ jobs:
       - run: "ruff format --check --diff"
   
   linting:
+    name: "Check Code Linting"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,24 +29,33 @@ jobs:
           args: "--version"
       - run: "ruff check --diff"
 
-  tests:
+  test_matrix_prep:
+    name: "Prepare Test Matrix"
     runs-on: ubuntu-latest
+    outputs:
+      matrix: "${{ steps.set-matrix.outputs.matrix }}"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv tool install tox
+      - id: set-matrix
+        run: |
+          matrix=$(tox -l | jq -Rc 'select(test("^py\\d+.*django\\d+")) | capture("^py(?<python>\\d+).*django(?<django>\\d+)") | {"python": (.python | tostring | .[0:1] + "." + .[1:]), "django": (.django | tostring | .[0:1] + "." + .[1:])}' | jq -sc '{include: .}')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  test:
+    name: "Test Django ${{ matrix.django }} | Python ${{ matrix.python }}"
+    needs: test_matrix_prep
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.test_matrix_prep.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v3
+    - run: uv tool install tox
     - uses: actions/setup-python@v4
       with:
-        python-version: |
-            3.8
-            3.9
-            3.10
-            3.11
-            3.12
-            3.13
-    - name: Install tox
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
+        python-version: ${{ matrix.python }}
     - name: Run tox
-      # we skip the 'ruff' env here, because we are running it in a separate 
-      # parallel job already
-      run: tox --skip-env ruff
+      run: tox run -e py$(echo "${{ matrix.python }}" | tr -d '.')-django$(echo "${{ matrix.django }}" | tr -d '.')


### PR DESCRIPTION
This change runs each django/python combination we have configured in tox to run as a separate github job.
So instead of having to wait ~35min for all test combinations to run in a single job, the first django/python combinations will already be done after 1min and all combinations will be done after ~4min.

The github action runs `tox -l` to introspect the exact combinations we want to run from the tox file, avoiding duplication of our test-matrix configuration in tox and the github action.

The test output looks like this now: 
<img width="924" height="460" alt="image" src="https://github.com/user-attachments/assets/a103a746-c33d-483c-9b8c-20b2fd5d7e8b" />
