### PR TITLE
Refactor models to use abstract base model for consistency and compatibility

### DIFF
--- a/oidc_provider/migrations/0028_alter_ids_to_bigautofield.py
+++ b/oidc_provider/migrations/0028_alter_ids_to_bigautofield.py
@@ -1,0 +1,55 @@
+# Generated migration to convert id fields to BigAutoField
+
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oidc_provider", "0027_alter_rsakey_options"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="client",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="code",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="responsetype",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="rsakey",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="token",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="userconsent",
+            name="id",
+            field=models.BigAutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+    ]

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -35,7 +35,21 @@ class ResponseTypeManager(models.Manager):
         return self.get(value=value)
 
 
-class ResponseType(models.Model):
+class BaseModel(models.Model):
+    """
+    Abstract base model with a BigAutoField primary key (64 bits).
+    Makes sure compatibility with modern Django projects (+3.2) that use BigAutoField as default.
+    """
+
+    id = models.BigAutoField(
+        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+    )
+
+    class Meta:
+        abstract = True
+
+
+class ResponseType(BaseModel):
     objects = ResponseTypeManager()
 
     value = models.CharField(
@@ -55,7 +69,7 @@ class ResponseType(models.Model):
         return "{0}".format(self.description)
 
 
-class Client(models.Model):
+class Client(BaseModel):
     name = models.CharField(max_length=100, default="", verbose_name=_("Name"))
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -178,7 +192,7 @@ class Client(models.Model):
         return self.redirect_uris[0] if self.redirect_uris else ""
 
 
-class BaseCodeTokenModel(models.Model):
+class BaseCodeTokenModel(BaseModel):
     client = models.ForeignKey(Client, verbose_name=_("Client"), on_delete=models.CASCADE)
     expires_at = models.DateTimeField(verbose_name=_("Expiration Date"))
     _scope = models.TextField(default="", verbose_name=_("Scopes"))
@@ -267,7 +281,7 @@ class UserConsent(BaseCodeTokenModel):
         unique_together = ("user", "client")
 
 
-class RSAKey(models.Model):
+class RSAKey(BaseModel):
     key = models.TextField(verbose_name=_("Key"), help_text=_("Paste your private RSA Key here."))
 
     class Meta:

--- a/oidc_provider/tests/cases/test_model_big_auto_field.py
+++ b/oidc_provider/tests/cases/test_model_big_auto_field.py
@@ -1,0 +1,79 @@
+from django.db import models
+from django.test import TestCase
+
+from oidc_provider.models import BaseModel
+from oidc_provider.models import Client
+from oidc_provider.models import Code
+from oidc_provider.models import ResponseType
+from oidc_provider.models import RSAKey
+from oidc_provider.models import Token
+from oidc_provider.models import UserConsent
+
+
+class BigAutoFieldTest(TestCase):
+    """
+    Test to verify that all models in oidc_provider use BigAutoField as primary key.
+    This ensures compatibility with modern Django projects (3.2+).
+    """
+
+    def test_models_inherit_from_basemodel(self):
+        """
+        Verify that all required models inherit from BaseModel.
+        """
+        models_to_check = [
+            Client,
+            Code,
+            ResponseType,
+            Token,
+            UserConsent,
+            RSAKey,
+        ]
+
+        for model_class in models_to_check:
+            self.assertTrue(
+                issubclass(model_class, BaseModel),
+                f"{model_class.__name__} should inherit from BaseModel.",
+            )
+
+    def test_id_fields_are_bigautofield(self):
+        """
+        Verify that the 'id' field of all models is BigAutoField.
+        """
+        models_to_check = {
+            "Client": Client,
+            "Code": Code,
+            "ResponseType": ResponseType,
+            "RSAKey": RSAKey,
+            "Token": Token,
+            "UserConsent": UserConsent,
+        }
+
+        for model_name, model_class in models_to_check.items():
+            id_field = model_class._meta.get_field("id")
+
+            self.assertIsInstance(
+                id_field,
+                models.BigAutoField,
+                f"The 'id' field of {model_name} should be BigAutoField.",
+            )
+
+    def test_bigautofield_is_primary_key(self):
+        """
+        Verify that the BigAutoField is set as the primary key.
+        """
+        models_to_check = {
+            "Client": Client,
+            "Code": Code,
+            "ResponseType": ResponseType,
+            "RSAKey": RSAKey,
+            "Token": Token,
+            "UserConsent": UserConsent,
+        }
+
+        for model_name, model_class in models_to_check.items():
+            id_field = model_class._meta.get_field("id")
+
+            self.assertTrue(
+                id_field.primary_key,
+                f"The 'id' field of {model_name} should be the primary key.",
+            )


### PR DESCRIPTION
### Problem Description
As of Django 3.2, the default setting for `DEFAULT_AUTO_FIELD` in new projects is `"django.db.models.BigAutoField"`.

When `django-oidc-provider` is used in a Django project configured with this modern default (`"django.db.models.BigAutoField"`), the application's models may still default to using `models.AutoField` (32-bit integer) for their primary keys, causing potential:

1. Database warnings (`models.W042`).
2. Inconsistencies and conflicts when running migrations if the consuming project attempts to enforce `BigAutoField` globally.

The conflict arises because while the library explicitly sets `DEFAULT_AUTO_FIELD = "django.db.models.AutoField"` (which is good practice for stability), it does not provide a subsequent migration to transition existing models to `BigAutoField`, which is the preferred type for high-volume applications and the modern Django default.

### Proposed Solution (Best Practice)
To ensure the library remains robust and compatible with modern Django projects without requiring users to fork the repository:

1. Update Models: Explicitly define the primary key for all `oidc_provider` models using `models.BigAutoField` in `oidc_provider/models.py`. This is the recommended best practice for third-party packages to avoid relying on the host project's default settings.

Example change in `models.py`:

```python
# Ensure ID is explicitly set to BigAutoField
id = models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')
```

2. Add Migration: Include a new migration file (similar to the one provided above) to officially change the existing primary key fields (`id`) on all relevant models (`Client`, `Code`, `ResponseType`, `RsaKey`, `Token`, `UserConsent`) from `AutoField` to `BigAutoField`.

This two-step process ensures all future installations use the 64-bit integer keys, and existing installations can smoothly transition without data loss or manual migration creation.